### PR TITLE
Load default language after git pull

### DIFF
--- a/stl
+++ b/stl
@@ -625,6 +625,7 @@ function loadLangFile {
 					echo "ERROR" "${FUNCNAME[0]} - language file '$LAFI' missing - downloading ' $PROJECTPAGE' and trying again"
 					gitPullStl
 					${FUNCNAME[0]}
+                                        loadLangFile "$STLDEFLANG"
 				fi
 			fi
 		fi


### PR DESCRIPTION
Hello,

Related to https://github.com/frostworx/steamtinkerlaunch/issues/138 I had the same issue so I took a look and I think it just miss that it need to try again to load the language.

Possible issue is maybe that it could have a loop if there is an issue. Pretty hard that the issue can happen but maybe you have a better idea to fix that properly. Maybe with a counter or a way to do only the pull one time, I let you modify the PR if needed.