### PR TITLE
Fix yad version check if statement

### DIFF
--- a/stl
+++ b/stl
@@ -9054,7 +9054,7 @@ function checkIntDeps {
 		MINYAD="7.2"
 		YADVER="0"
 
-		if [ -f "$YAD" ]; then
+		if command -v yad &>/dev/null; then
 			YADVER="$("$YAD" --version | tail -n1 | cut -d ' ' -f1)"
 		fi
 


### PR DESCRIPTION
I was having stl report that my version of yad was '0'. Having checked
the code I found that the $YAD variable was just set to 'yad' which
meant that it would be checking for a file called yad in the current
directory. Swapping to command -v which will use the PATH variable to
determine if yad is present.