### PR TITLE
Change ReShade WINEDLLOVERRIDES to add to variable

### DIFF
--- a/stl
+++ b/stl
@@ -5604,7 +5604,7 @@ function useReshade {
 			fi
 
 			writelog "INFO" "${FUNCNAME[0]} - Setting WINEDLLOVERRIDES for ReShade: dxgi=n,b;d3d9=n,b;d3dcompiler_47=n,b"
-			export WINEDLLOVERRIDES="dxgi=n,b;d3d9=n,b;d3dcompiler_47=n,b"
+			export WINEDLLOVERRIDES="$WINEDLLOVERRIDES;dxgi=n,b;d3d9=n,b;d3dcompiler_47=n,b"
 		else
 			if [ -f "$EFD/$RSINI" ] && [ ! -f "$EFD/$RSENABLED" ] && [ ! -f "$EFD/$RSDISABLED" ] ; then
 				writelog "INFO" "${FUNCNAME[0]} - USERESHADE is '$USERESHADE' - looks like Reshade was installed previously using '$PROGCMD' without creating '$RSENABLED' - recreating it now"


### PR DESCRIPTION
Fixes #251. I didn't see anywhere else where this variable is set, so this should do it. Works in my test (Dark Souls, using DSFix which needs a dinput override, along with enabling ReShade in Game Menu).