### PR TITLE
CheatEngine: Fallback to WayBack Machine Archive for 7.2

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -10,6 +10,7 @@ PROGVERS="v8.0"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
+CEWAYBACKURL="https://web.archive.org/web/20210118065254if_"
 PROJECTPAGE="$GHURL/frostworx/${PROGNAME,,}"
 PPW="$PROJECTPAGE/wiki"
 CURWIKI="$PPW"
@@ -10048,15 +10049,16 @@ function checkGamConLaunch {
 
 function downloadCheatEngine {
 	# yes I know 7.3 is released - proper PR accepted, I won't spend more time on CE generally
+	CHEATENGINEURLEVAL="$CHEATENGINEURL/download/$CHEATENGINEVERSION/$CESET"
 	if [ "$CHEATENGINEVERSION" == "7.2" ]; then
-		writelog "ERROR" "${FUNCNAME[0]} - Cheat Engine upstream removed version 7.2 - check the wiki for details!"
-	else
-		CESET="$1"
-		writelog "INFO" "${FUNCNAME[0]} - Downloading '$CESET' into '$CEDLDIR'"
-		notiShow "$(strFix "$NOTY_DLCE" "$CESET")" "S"
-		dlCheck "$CHEATENGINEURL/download/$CHEATENGINEVERSION/$CESET" "$CEDLDIR/$CESET" "X" "Downloading '$CESET'"
-		notiShow "$GUI_DONE" "S"
+		writelog "WARNING" "${FUNCNAME[0]} - Cheat Engine upstream removed version 7.2 - defaulting to wayback machine archive"
+		CHEATENGINEURLEVAL="$CEWAYBACKURL/$CHEATENGINEURLEVAL"
 	fi
+	CESET="$1"
+	writelog "INFO" "${FUNCNAME[0]} - Downloading '$CESET' into '$CEDLDIR'"
+	notiShow "$(strFix "$NOTY_DLCE" "$CESET")" "S"
+	dlCheck "$CHEATENGINEURLEVAL" "$CEDLDIR/$CESET" "X" "Downloading '$CESET'"
+	notiShow "$GUI_DONE" "S"
 }
 
 function installCheatEngine {


### PR DESCRIPTION
A quick hotfix to support installation of ad-less cheat engine 7.2 installer mirror.

We utilize the Internet Archive's Wayback Machine (https://archive.org/web/) mirror (https://web.archive.org/web/20210118065254if_/https://github.com/cheat-engine/cheat-engine/releases/download/7.2/CheatEngine72.exe) to ensure that we do not have to rely on community members to repackage or redistribute the 7.2 installer. 

The only notable potential downside are:
1) end-users being subject to being rate limited due to large amounts of download requests coming from their IP.
2) dependency on web archive being available and up
3) ability to access and resolve web archive domain name