### PR TITLE
Fix symlinks not generating when steamlibrary has spaces or the target directories are also links

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -10453,12 +10453,12 @@ function setModGameReg {
 }
 
 function setModGameSyms {
-	SYMODE="$1"
-	SRCPFX="$2"
-	MODGNA="$3"
-	MODGID="$4"
-	DSTPFX="$5"
-	CHKAPMA="$6"
+	SYMODE="$1" # MODE - either 'li' or 'set'
+	SRCPFX="$2" # Game prefix
+	MODGNA="$3" # Game name
+	MODGID="$4" # Game Steam ID
+	DSTPFX="$5" # Mod manager prefix
+	CHKAPMA="$6" # Game app-manifest (.acf)
 
 	if [ ! -d "$SRCPFX" ]; then
 		writelog "SKIP" "${FUNCNAME[0]} - '$SRCPFX' missing - looks like the game was removed or never started yet"
@@ -10482,7 +10482,7 @@ function setModGameSyms {
 				while read -r gdir; do
 					DSTL="$DSTPFX/$DRCU/$STUS/$DOCS/$MYGAMES/${gdir##*/}"
 					prepModGameSym "$DSTL" "$gdir"
-				done <<< "$(find "$SRCPFX/$DRCU/$STUS/$DOCS/$MYGAMES" -mindepth 1 -maxdepth 1 -type d)"
+				done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$DOCS/$MYGAMES" -mindepth 1 -maxdepth 1 '(' -type d -o -type l -xtype d ')')"
 			fi
 
 			if [ -d "$SRCPFX/$DRCU/$STUS/$DOCS" ]; then
@@ -10491,30 +10491,30 @@ function setModGameSyms {
 						while read -r gsdir; do
 							DSTL="$DSTPFX/$DRCU/$STUS/$DOCS/$MYGAMES/${gsdir##*/}"
 							prepModGameSym "$DSTL" "$gsdir"
-						done <<< "$(find "$SRCPFX/$DRCU/$STUS/$DOCS/$MYGAMES" -mindepth 1 -maxdepth 1 -type d)"
+						done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$DOCS/$MYGAMES" -mindepth 1 -maxdepth 1 '(' -type d -o -type l -xtype d ')')"
 					elif [ "${gdir##*/}" == "$EAGA" ]; then
 						mkProjDir "$DSTPFX/$DRCU/$STUS/$DOCS/$EAGA"
 						while read -r geadir; do
 							DSTL="$DSTPFX/$DRCU/$STUS/$DOCS/$EAGA/${geadir##*/}"
 							prepModGameSym "$DSTL" "$geadir"
-						done <<< "$(find "$SRCPFX/$DRCU/$STUS/$DOCS/$EAGA" -mindepth 1 -maxdepth 1 -type d)"
+						done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$DOCS/$EAGA" -mindepth 1 -maxdepth 1 '(' -type d -o -type l -xtype d ')')"
 					elif [ "${gdir##*/}" == "$LAGA" ]; then
 						mkProjDir "$DSTPFX/$DRCU/$STUS/$DOCS/$LAGA"
 						while read -r gladir; do
 							DSTL="$DSTPFX/$DRCU/$STUS/$DOCS/$LAGA/${gladir##*/}"
 							prepModGameSym "$DSTL" "$gladir"
-						done <<< "$(find "$SRCPFX/$DRCU/$STUS/$DOCS/$LAGA" -mindepth 1 -maxdepth 1 -type d)"
+						done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$DOCS/$LAGA" -mindepth 1 -maxdepth 1 '(' -type d -o -type l -xtype d ')')"
 					elif [ "${gdir##*/}" == "$BIOW" ]; then
 						mkProjDir "$DSTPFX/$DRCU/$STUS/$DOCS/$BIOW"
 						while read -r gbiodir; do
 							DSTL="$DSTPFX/$DRCU/$STUS/$DOCS/$BIOW/${gbiodir##*/}"
 							prepModGameSym "$DSTL" "$gbiodir"
-						done <<< "$(find "$SRCPFX/$DRCU/$STUS/$DOCS/$BIOW" -mindepth 1 -maxdepth 1 -type d)"
+						done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$DOCS/$BIOW" -mindepth 1 -maxdepth 1 '(' -type d -o -type l -xtype d ')')"
 					else
 						DSTL="$DSTPFX/$DRCU/$STUS/$DOCS/${gdir##*/}"
 						prepModGameSym "$DSTL" "$gdir"
 					fi
-				done <<< "$(find "$SRCPFX/$DRCU/$STUS/$DOCS" -mindepth 1 -maxdepth 1 -type d -not -empty)"
+				done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$DOCS" -mindepth 1 -maxdepth 1 -not -empty '(' -type d -o -type l -xtype d ')')"
 			fi
 
 			if [ -d "$SRCPFX/$DRCU/$STUS/$MYDOCS" ] && [ ! -L "$SRCPFX/$DRCU/$STUS/$MYDOCS" ]; then
@@ -10523,30 +10523,30 @@ function setModGameSyms {
 						while read -r gsdir; do
 							DSTL="$DSTPFX/$DRCU/$STUS/$DOCS/$MYGAMES/${gsdir##*/}"
 							prepModGameSym "$DSTL" "$gsdir"
-						done <<< "$(find "$SRCPFX/$DRCU/$STUS/$MYDOCS/$MYGAMES" -mindepth 1 -maxdepth 1 -type d)"
+						done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$MYDOCS/$MYGAMES" -mindepth 1 -maxdepth 1 '(' -type d -o -type l -xtype d ')')"
 					elif [ "${gdir##*/}" == "$EAGA" ]; then
 						mkProjDir "$DSTPFX/$DRCU/$STUS/$DOCS/$EAGA"
 						while read -r geadir; do
 							DSTL="$DSTPFX/$DRCU/$STUS/$DOCS/$EAGA/${geadir##*/}"
 							prepModGameSym "$DSTL" "$geadir"
-						done <<< "$(find "$SRCPFX/$DRCU/$STUS/$MYDOCS/$EAGA" -mindepth 1 -maxdepth 1 -type d)"
+						done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$MYDOCS/$EAGA" -mindepth 1 -maxdepth 1 '(' -type d -o -type l -xtype d ')')"
 					elif [ "${gdir##*/}" == "$LAGA" ]; then
 						mkProjDir "$DSTPFX/$DRCU/$STUS/$DOCS/$LAGA"
 						while read -r gladir; do
 							DSTL="$DSTPFX/$DRCU/$STUS/$DOCS/$LAGA/${gladir##*/}"
 							prepModGameSym "$DSTL" "$gladir"
-						done <<< "$(find "$SRCPFX/$DRCU/$STUS/$MYDOCS/$LAGA" -mindepth 1 -maxdepth 1 -type d)"
+						done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$MYDOCS/$LAGA" -mindepth 1 -maxdepth 1 '(' -type d -o -type l -xtype d ')')"
 					elif [ "${gdir##*/}" == "$BIOW" ]; then
 						mkProjDir "$DSTPFX/$DRCU/$STUS/$DOCS/$BIOW"
 						while read -r gbiodir; do
 							DSTL="$DSTPFX/$DRCU/$STUS/$DOCS/$BIOW/${gbiodir##*/}"
 							prepModGameSym "$DSTL" "$gbiodir"
-						done <<< "$(find "$SRCPFX/$DRCU/$STUS/$DOCS/$BIOW" -mindepth 1 -maxdepth 1 -type d)"
+						done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$DOCS/$BIOW" -mindepth 1 -maxdepth 1 '(' -type d -o -type l -xtype d ')')"
 					else
 						DSTL="$DSTPFX/$DRCU/$STUS/$DOCS/${gdir##*/}"
 						prepModGameSym "$DSTL" "$gdir"
 					fi
-				done <<< "$(find "$SRCPFX/$DRCU/$STUS/$MYDOCS" -mindepth 1 -maxdepth 1 -type d -not -empty)"
+				done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$MYDOCS" -mindepth 1 -maxdepth 1 -not -empty '(' -type d -o -type l -xtype d ')')"
 			fi
 
 			if [ -d "$SRCPFX/$DRCU/$STUS/$APDA" ]; then
@@ -10555,7 +10555,7 @@ function setModGameSyms {
 						DSTL="$DSTPFX/$DRCU/$STUS/$ADRO/${gdir##*/}"
 						prepModGameSym "$DSTL" "$gdir"
 					fi
-				done <<< "$(find "$SRCPFX/$DRCU/$STUS/$APDA" -mindepth 1 -maxdepth 1 -type d -not -empty)"
+				done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$APDA" -mindepth 1 -maxdepth 1 -not -empty '(' -type d -o -type l -xtype d ')')"
 			fi
 
 			if [ -d "$SRCPFX/$DRCU/$STUS/$ADLO" ]; then
@@ -10569,7 +10569,7 @@ function setModGameSyms {
 							prepModGameSym "$DSTL" "$gdir"
 						fi
 					fi
-				done <<< "$(find "$SRCPFX/$DRCU/$STUS/$ADLO" -mindepth 1 -maxdepth 1 -type d -not -empty)"
+				done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$ADLO" -mindepth 1 -maxdepth 1 -not -empty '(' -type d -o -type l -xtype d ')')"
 			fi
 
 			if [ -d "$SRCPFX/$DRCU/$STUS/$ADLOLO" ]; then
@@ -10583,14 +10583,14 @@ function setModGameSyms {
 							prepModGameSym "$DSTL" "$gdir"
 						fi
 					fi
-				done <<< "$(find "$SRCPFX/$DRCU/$STUS/$ADLOLO" -mindepth 1 -maxdepth 1 -type d -not -empty)"
+				done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$ADLOLO" -mindepth 1 -maxdepth 1 -not -empty '(' -type d -o -type l -xtype d ')')"
 			fi
 						
 			if [ -d "$SRCPFX/$DRCU/$STUS/$ADLO/LOOT" ]; then
 				while read -r gdir; do
 					DSTL="$MODLOOT/${gdir##*/}"
 					prepModGameSym "$DSTL" "$gdir"
-				done <<< "$(find "$SRCPFX/$DRCU/$STUS/$ADLO/LOOT" -mindepth 1 -maxdepth 1 -type d -not -empty)"
+				done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$ADLO/LOOT" -mindepth 1 -maxdepth 1 -not -empty '(' -type d -o -type l -xtype d ')')"
 			fi
 			
 			if [ -d "$SRCPFX/$DRCU/$STUS/$LSAD" ]; then
@@ -10599,7 +10599,7 @@ function setModGameSyms {
 						DSTL="$DSTPFX/$DRCU/$STUS/$ADLO/${gdir##*/}"
 						prepModGameSym "$DSTL" "$gdir"
 					fi
-				done <<< "$(find "$SRCPFX/$DRCU/$STUS/$LSAD" -mindepth 1 -maxdepth 1 -type d -not -empty)"
+				done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$LSAD" -mindepth 1 -maxdepth 1 -not -empty '(' -type d -o -type l -xtype d ')')"
 			fi
 
 			if [ -d "$SRCPFX/$DRCU/$STUS/$SAGE/$CDPR" ]; then
@@ -10607,7 +10607,7 @@ function setModGameSyms {
 				while read -r gdir; do
 						DSTL="$DSTPFX/$DRCU/$STUS/$SAGE/$CDPR/${gdir##*/}"
 						prepModGameSym "$DSTL" "$gdir"
-				done <<< "$(find "$SRCPFX/$DRCU/$STUS/$SAGE/$CDPR" -mindepth 1 -maxdepth 1 -type d -not -empty)"
+				done <<< "$(find -L "$SRCPFX/$DRCU/$STUS/$SAGE/$CDPR" -mindepth 1 -maxdepth 1 -not -empty '(' -type d -o -type l -xtype d ')')"
 			fi
 
 			MSREG="$SRCPFX/$SREG"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -10961,6 +10961,7 @@ function getVortexSupported {
 		fi
 	}
 
+	setVortexVars
 	VGPDIR="$VORTEXINSTDIR/$RABP"
 	VUPDIR="$VORTEXPFX/$DRCU/$STUS/$APDA/Vortex/plugins"
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -1259,6 +1259,25 @@ function listAppManifests {
 		fi
 	}
 
+	# getBIF takes a string containing a BaseInstallFolder or path and returns the 
+	function getBIF {
+		# REGEX needs to be a variable, quoted string literals are not treated as regexps by test
+		# BASH_REMATCH[1] will be the key (BaseInstallFolder* or path)
+		# BASH_REMATCH[2] will be the value (the actual steam library folder)
+		local REGEX='"(BaseInstallFolder[^"]*|path)"\s+"(.*)"\s*$'
+
+		# Use either first arg, or stdin if arg is empty
+		local in=$1
+		if [ -z "$in" ]; then read in; fi
+
+		# Test the regex against input, then print the extracted path to stdout
+		if [ $in =~ $REGEX ] && [ ! -z ${BASH_REMATCH[2]} ]; then
+			echo "${BASH_REMATCH[2]}"
+		else
+			writelog "WARN" "${FUNCNAME[0]} - Failed to parse Base Install Folder from '$in'"
+		fi
+	}
+
 	if [ -d "$DEFSTEAMAPPS" ]; then
 		findAppMa "$DEFSTEAMAPPS"
 	else
@@ -1269,7 +1288,7 @@ function listAppManifests {
 		writelog "INFO" "${FUNCNAME[0]} - Searching appmanifest files in '$CFGVDF' and '$LFVDF'" "X" "$APPMALOG"
 		while read -r BIF; do
 			findAppMa "${BIF//\"/}/$SA"
-		done <<< "$(grep "BaseInstallFolder\|\"path\"" "$CFGVDF" "$LFVDF" 2>/dev/null | awk '{print $3}' | sort -u)"
+		done <<< "$(grep "\"BaseInstallFolder\|\"path\"" "$CFGVDF" "$LFVDF" 2>/dev/null | getBIF | sort -u)"
 	else
 		writelog "SKIP" "${FUNCNAME[0]} - Neither file CFGVDF '$CFGVDF' nor file LFVDF '$LFVDF' found - this should not happen! - skipping"
 	fi


### PR DESCRIPTION
The first commit fixes `vortex list-supported` not being initialised properly. The second commit fixes `listAppManifests` not supporting steam libraries with whitespace in the path (e.g. `~/Games/Steam Library`). Fixes #389 

EDIT: the third commit ensures `setModGameSyms` correctly discovers symlink targets when the target is itself a link (or a child of a link).

<details><summary><strong>original comments</strong></summary>

I'm marking this as a draft though, because (for me at least) this doesn't entirely fix the symlink issue. Probably because I have other symlinks setup manually in the game `compatdata`s, I'm assuming something in the code doesn't play nicely with creating symlinks that point through other symlinks.

For instance, I have `Documents/My Games` symlinked in each of my game `compatdata`s, and no symlinks were generated pointing to anything in `Documents/My Games`... A similar story with my Fallout 4 appdata:

![image](https://user-images.githubusercontent.com/5046562/147508705-8e42ce58-f441-4e23-93f8-e7cfcc42d78d.png)

</details>