### PR TITLE
Add app name to default notifier

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -2226,7 +2226,7 @@ function setDefaultCfgValues {
 		if [ -z "$MAXASK" ]								; then	MAXASK="3"; fi
 		if [ -z "$BROWSER" ]							; then	BROWSER="$(command -v "firefox")"; fi
 		if [ -z "$NOTY" ]								; then	NOTY="$(command -v "notify-send")"; fi
-		if [ -z "$NOTYARGS" ]							; then	NOTYARGS="-i $STLICON"; fi
+		if [ -z "$NOTYARGS" ]							; then	NOTYARGS="-i $STLICON -a $PROGNAME"; fi
 		if [ -z "$USENOTIFIER" ]						; then	USENOTIFIER="1"; fi
 		if [ -z "$NETMON" ]								; then	NETMON="$(command -v "netstat")"; fi
 		if [ -z "$NETOPTS" ]							; then	NETOPTS="-taucp -W"; fi


### PR DESCRIPTION
With `notify-send`, the default notifier, the `-a` flag can be used to set the name of the application. This is set to the existing `$PROGNAME`. It is also possible to use an `--app-name=` syntax, but going with `-a` keeps in line with the existing `-i` syntax for adding the icon to the notification.

This flag is not mentioned in the manual for `notify-send` on my Arch Linux installations, but it is mention on [this](http://vaskovsky.net/notify-send/linux.html) page and I can verify that the flag works. Discussion and testing on other distributions may be required to make sure this doesn't raise errors or unwanted behaviours.

Example of a game launch notification with this change on KDE Plasma:
![Notification with -a flag on KDE Plasma](https://user-images.githubusercontent.com/7917345/150882109-494d1297-969b-4555-998b-1354c8500a22.png)

Alternatively, if this change is undesirable, steps for adding this flag manually should be included in the [Notifier wiki page](https://github.com/frostworx/steamtinkerlaunch/wiki/Notifier).

Closes #403.