### PR TITLE
Set WINE_FULLSCREEN_FSR_STRENGTH default value to 2

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -2504,7 +2504,7 @@ function setDefaultCfgValues {
 		if [ -z "$CLEANPROTONTEMP" ]					; then	CLEANPROTONTEMP="0"; fi
 		if [ -z "$WINE_FULLSCREEN_INTEGER_SCALING" ]	; then	WINE_FULLSCREEN_INTEGER_SCALING="0"; fi
 		if [ -z "$WINE_FULLSCREEN_FSR" ]				; then	WINE_FULLSCREEN_FSR="0"; fi
-		if [ -z "$WINE_FULLSCREEN_FSR_STRENGTH" ]		; then	WINE_FULLSCREEN_FSR_STRENGTH="5"; fi
+		if [ -z "$WINE_FULLSCREEN_FSR_STRENGTH" ]		; then	WINE_FULLSCREEN_FSR_STRENGTH="2"; fi
 		if [ -z "$STLWINEDEBUG" ]						; then	STLWINEDEBUG="-all"; fi
 		if [ -z "$STLWINEDLLOVERRIDES" ]				; then	STLWINEDLLOVERRIDES="$NON"; fi
 		if [ -z "$USERSTART" ]							; then	USERSTART="$DUMMYBIN"; fi


### PR DESCRIPTION
I may not have implemented this correctly but I wanted to make an attempt at this, get feedback if it is not implemented correctly and also get a discussion going :smile: 

The default sharpening value for FSR right now is 5, however [the recommended default](https://github.com/ValveSoftware/wine/pull/116) for this patch is 2. Gamescope [also uses](https://github.com/Plagman/gamescope/pull/360/files#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R146) 2.

This PR aims to set the default value to 2 based on this. Feedback and guidance welcome if I did not change the correct value, I couldn't get this to display but think that might be a different problem.