### PR TITLE
Change Integer Scaling flag to reflect updated gamescope code

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -8553,7 +8553,7 @@ function GameScopeGui {
 	fi
 
 	if [ -z "$GSIS" ]; then
-		if grep -q "\-n" <<< "$GAMESCOPE_ARGS"; then
+		if grep -q "\-i" <<< "$GAMESCOPE_ARGS"; then
 			GSIS="1"
 		else
 			GSIS="0"
@@ -8628,7 +8628,7 @@ function GameScopeGui {
 						fi	
 
 						if [ "$GSIS" == "TRUE" ]; then
-							GAMESCOPE_ARGS="${GAMESCOPE_ARGS} -n"
+							GAMESCOPE_ARGS="${GAMESCOPE_ARGS} -i"
 						fi
 
 						if [ "$GSFS" == "TRUE" ]; then


### PR DESCRIPTION
Updates the Integer Scaling option for Gamescope to use `-i` instead of `-n`, based on [this Gamescope PR](https://github.com/Plagman/gamescope/pull/450). The `-n` flag seems to be used for Nearest Neighbor filtering, which could also be added, but that is for a different PR :smile: 

Looking at the Gamescope readme it seems like Integer Scaling can't be toggled with a keyboard shortcut, so passing it at launch is the only way to enable it as far as I can tell. `Super+I` is used for FSR now, and `Super+N` toggles Nearest Neighbor filtering.

I compared with this option enabled and disabled, and it is somewhat noticeable to me, so I believe it to be working. Since I don't think it can be toggled I could not do an in-game toggle to view the difference, so I compared Integer Scaling on/off to screenshots.