### PR TITLE
Enable support for winesync

### DIFF
--- a/lang/dutch.txt
+++ b/lang/dutch.txt
@@ -55,6 +55,7 @@ DESC_PROTON_NO_D3D11="d3d11.dll uitschakelen voor D3D11 spellen die terug kunnen
 DESC_PROTON_NO_ESYNC="Gebruik geen eventfd gebaseerde in-process synchronisatie primitives"
 DESC_PROTON_NO_FSYNC="Gebruik geen futex gebaseerde in-process synchronisatie primitives"
 DESC_PROTON_USE_WINED3D="Gebruik OpenGL gebaseerde WineD3D in plaats van Vulkan gebaseerder DXVK voor D3D11, D3D10 en D3D9"
+DESC_ENABLE_WINESYNC="Use Winesync instead of esync/fsync. The winesync kernel module and a compatible Proton need to be used."
 DESC_REGEDIT="Sta register aanpassingen toe voor dit spel"
 DESC_RESHADESRCDIR="De folder waar ReShade componenten zijn opgeslagen en ingeladen"
 DESC_RESHADE_DEPTH3D="Gebruik de Depth3D shader met ReShade"

--- a/lang/english.txt
+++ b/lang/english.txt
@@ -54,6 +54,7 @@ DESC_PROTON_NO_D3D10="Disable d3d10.dll and dxgi.dll, for D3D10 games which can 
 DESC_PROTON_NO_D3D11="Disable d3d11.dll, for D3D11 games which can fall back to and run better with D3D9"
 DESC_PROTON_NO_ESYNC="Do not use eventfd-based in-process synchronization primitives"
 DESC_PROTON_NO_FSYNC="Do not use futex-based in-process synchronization primitives"
+DESC_ENABLE_WINESYNC="Use Winesync instead of esync/fsync. The winesync kernel module and a compatible Proton need to be used."
 DESC_PROTON_USE_WINED3D="Use OpenGL-based WineD3D instead of Vulkan-based DXVK for D3D11, D3D10 and D3D9"
 DESC_REGEDIT="Allow registry changes for this game"
 DESC_RESHADESRCDIR="The directory where ReShade components are stored and loaded"

--- a/lang/englishUK.txt
+++ b/lang/englishUK.txt
@@ -54,6 +54,7 @@ DESC_PROTON_NO_D3D10="Disable d3d10.dll and dxgi.dll, for D3D10 games which can 
 DESC_PROTON_NO_D3D11="Disable d3d11.dll, for D3D11 games which can fall back to and run better with D3D9"
 DESC_PROTON_NO_ESYNC="Do not use eventfd-based in-process synchronisation primitives"
 DESC_PROTON_NO_FSYNC="Do not use futex-based in-process synchronisation primitives"
+DESC_ENABLE_WINESYNC="Use Winesync instead of esync/fsync. The winesync kernel module and a compatible Proton need to be used."
 DESC_PROTON_USE_WINED3D="Use OpenGL-based WineD3D instead of Vulkan-based DXVK for D3D11, D3D10 and D3D9"
 DESC_REGEDIT="Allow registry changes for this game"
 DESC_RESHADESRCDIR="The directory where ReShade components are stored and loaded"

--- a/lang/french.txt
+++ b/lang/french.txt
@@ -54,6 +54,7 @@ DESC_PROTON_NO_D3D10="Désactiver d3d10.dll et dxgi.dll pour les jeux D3D10 qui 
 DESC_PROTON_NO_D3D11="Désactiver d3d11.dll, pour les jeux D3D11 qui peuvent basculer vers D3D9 et ainsi mieux fonctionner"
 DESC_PROTON_NO_ESYNC="Do not use eventfd-based in-process synchronization primitives"
 DESC_PROTON_NO_FSYNC="Do not use futex-based in-process synchronization primitives"
+DESC_ENABLE_WINESYNC="Use Winesync instead of esync/fsync. The winesync kernel module and a compatible Proton need to be used."
 DESC_PROTON_USE_WINED3D="Utiliser WineD3D (basé sur OpenGL) au lieu de DXVK (basé sur Vulkan) pour D3D11, D3D10 et D3D9"
 DESC_REGEDIT="Autoriser les changements en base de registre pour ce jeu"
 DESC_RESHADESRCDIR="Le répertoire où les composants de ReShade sont stockés et chargés"

--- a/lang/german.txt
+++ b/lang/german.txt
@@ -54,6 +54,7 @@ DESC_PROTON_NO_D3D10="Deaktiviere d3d10.dll und dxgi.dll, für d3d10 Spiele die 
 DESC_PROTON_NO_D3D11="Deaktiviere d3d11.dll, für d3d11 Spiele die einen Fallback auf d3d9 haben und damit besser funktionieren"
 DESC_PROTON_NO_ESYNC="Verwende nicht die 'eventfd-based in-process synchronization primitives'"
 DESC_PROTON_NO_FSYNC="Verwende nicht die 'futex-based in-process synchronization primitives'"
+DESC_ENABLE_WINESYNC="Use Winesync instead of esync/fsync. The winesync kernel module and a compatible Proton need to be used."
 DESC_PROTON_USE_WINED3D="Verwende OpenGL-basiertes wined3d anstatt dem Vulkan-basierten DXVK for d3d11, d3d10, and d3d9"
 DESC_REGEDIT="Registry Änderungen für das Spiel erlauben"
 DESC_RESHADESRCDIR="Der Download Ordner für ReShade Dateien"

--- a/lang/italian.txt
+++ b/lang/italian.txt
@@ -54,6 +54,7 @@ DESC_PROTON_NO_D3D10="Disabilita d3d10.dll e dxgi.dll, per i giochi d3d10 che po
 DESC_PROTON_NO_D3D11="Disabilita d3d11.dll, per i giochi d3d11 che possono ripiegare su d3d9 per girare meglio"
 DESC_PROTON_NO_ESYNC="Non usare le primitive di sincronizzazione eventfd-based in-process"
 DESC_PROTON_NO_FSYNC="Non usare le primitive di sincronizzazione futex-based in-process"
+DESC_ENABLE_WINESYNC="Use Winesync instead of esync/fsync. The winesync kernel module and a compatible Proton need to be used."
 DESC_PROTON_USE_WINED3D="Usa wined3d basato su OpenGL invece del DXVK basato su Vulkan per d3d11, d3d10 e d3d9"
 DESC_REGEDIT="Abilita modifiche ai registri per questo gioco"
 DESC_RESHADESRCDIR="Le cartelle nelle quali i componenti ReShade sono salvati e caricati"

--- a/lang/polish.txt
+++ b/lang/polish.txt
@@ -54,6 +54,7 @@ DESC_PROTON_NO_D3D10="Wyłącz d3d10.dll i dxgi.dll dla gier D3D10 które cofną
 DESC_PROTON_NO_D3D11="Wyłącz d3d11.dll dla gier D3D11 które cofną się i będą lepiej działać z D3D9"
 DESC_PROTON_NO_ESYNC="Nie używaj międzyprocesowych prymitywów synchronizacji bazujących na eventfd"
 DESC_PROTON_NO_FSYNC="Nie używaj prymitywów synchronizacji bazujących na futex"
+DESC_ENABLE_WINESYNC="Use Winesync instead of esync/fsync. The winesync kernel module and a compatible Proton need to be used."
 DESC_PROTON_USE_WINED3D="Używaj bazującego na OpenGL WineD3D zamiast bazującego na Vulkanie DXVK dla D3D11, D3D10 i D3D9"
 DESC_REGEDIT="Pozwalaj na zmiany w rejestrze dla tej gry"
 DESC_RESHADESRCDIR="Folder w którym komponent ReShade są przechowywane i wczytywane"

--- a/lang/russian.txt
+++ b/lang/russian.txt
@@ -54,6 +54,7 @@ DESC_PROTON_NO_D3D10="Отключить d3d10.dll и dxgi.dll, для d3d10 и�
 DESC_PROTON_NO_D3D11="Отключить d3d11.dll, для d3d11 игр, имеющих лучшую совместимость в режиме d3d9"
 DESC_PROTON_NO_ESYNC="Не использовать eventfd-based in-process synchronization primitives (ESYNC)"
 DESC_PROTON_NO_FSYNC="Не использовать futex-based in-process synchronization primitives(FSYNC)"
+DESC_ENABLE_WINESYNC="Use Winesync instead of esync/fsync. The winesync kernel module and a compatible Proton need to be used."
 DESC_PROTON_USE_WINED3D="Использовать основанную на OpenGL реализацию wined3d вместо использующей Vulkan DXVK для d3d11, d3d10, и d3d9"
 DESC_REGEDIT="Применить изменения Registry для этой игры"
 DESC_RESHADESRCDIR="Директория, в которой хранятся и загружаются компоненты ReShade"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -2511,6 +2511,7 @@ function setDefaultCfgValues {
 		if [ -z "$PROTON_NO_D3D10" ]					; then	PROTON_NO_D3D10="0"; fi
 		if [ -z "$PROTON_NO_ESYNC" ]					; then	PROTON_NO_ESYNC="0"; fi
 		if [ -z "$PROTON_NO_FSYNC" ]					; then	PROTON_NO_FSYNC="0"; fi
+		if [ -z "$ENABLE_WINESYNC" ]					; then	ENABLE_WINESYNC="0"; fi
 		if [ -z "$PROTON_ENABLE_NVAPI" ]				; then	PROTON_ENABLE_NVAPI="0"; fi
 		if [ -z "$PROTON_HIDE_NVIDIA_GPU" ]				; then	PROTON_HIDE_NVIDIA_GPU="1"; fi
 		if [ -z "$STL_VKD3D_CONFIG" ]					; then	STL_VKD3D_CONFIG="$NON"; fi
@@ -3066,6 +3067,8 @@ function saveCfg {
 			echo "PROTON_NO_ESYNC=\"$PROTON_NO_ESYNC\""
 			echo "## $DESC_PROTON_NO_FSYNC"
 			echo "PROTON_NO_FSYNC=\"$PROTON_NO_FSYNC\""
+			echo "## $DESC_ENABLE_WINESYNC"
+			echo "ENABLE_WINESYNC=\"$ENABLE_WINESYNC\""
 			echo "## $DESC_PROTON_ENABLE_NVAPI"
 			echo "PROTON_ENABLE_NVAPI=\"$PROTON_ENABLE_NVAPI\""
 			echo "## $DESC_PROTON_HIDE_NVIDIA_GPU"
@@ -4563,6 +4566,7 @@ function AllSettingsEntriesDummyFunction {
 --field="     $GUI_PROTON_NO_D3D11!$DESC_PROTON_NO_D3D11 ('PROTON_NO_D3D11')":CHK "${PROTON_NO_D3D11/#-/ -}" `#CAT_Proton` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_PROTON_NO_ESYNC!$DESC_PROTON_NO_ESYNC ('PROTON_NO_ESYNC')":CHK "${PROTON_NO_ESYNC/#-/ -}" `#CAT_Proton` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_PROTON_NO_FSYNC!$DESC_PROTON_NO_FSYNC ('PROTON_NO_FSYNC')":CHK "${PROTON_NO_FSYNC/#-/ -}" `#CAT_Proton` `#SUB_Checkbox` `#MENU_GAME` \
+--field="     $GUI_ENABLE_WINESYNC!$DESC_ENABLE_WINESYNC ('ENABLE_WINESYNC')":CHK "${ENABLE_WINESYNC/#-/ -}" `#CAT_Proton` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_PROTON_ENABLE_NVAPI!$DESC_PROTON_ENABLE_NVAPI ('PROTON_ENABLE_NVAPI')":CHK "${PROTON_ENABLE_NVAPI/#-/ -}" `#CAT_Proton` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_PROTON_PROTON_HIDE_NVIDIA_GPU!$DESC_PROTON_HIDE_NVIDIA_GPU ('PROTON_HIDE_NVIDIA_GPU')":CHK "${PROTON_HIDE_NVIDIA_GPU/#-/ -}" `#CAT_Proton` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_USEDLSS!$DESC_USEDLSS ('USEDLSS')":CHK "${USEDLSS/#-/ -}" `#CAT_Proton` `#SUB_Checkbox` `#MENU_GAME` \
@@ -15822,6 +15826,12 @@ function launchSteamGame {
 		export __GLX_VENDOR_LIBRARY_NAME=mesa
 		export MESA_LOADER_DRIVER_OVERRIDE=zink
 		export GALLIUM_DRIVER=zink
+	fi
+	
+	if [ "$ENABLE_WINESYNC" -eq 1 ]; then
+		export WINEESYNC=0
+		export WINEFSYNC=0
+		export WINEFSYNC_FUTEX2=0
 	fi
 
 	MAHUCMD=()


### PR DESCRIPTION
Just a quick pull request, I don't expect you will merge, but I thought it might be an interesting idea.

This will allow environment variables to be exported that can enable winesync to run. Winesync is an alternative for fsync, the latter can crash some games.

Winesync has a few downsides. It needs a seperate kernel module called "winesync" and a Wine (or Proton) build not based on staging and with esync and fsync disabled.

Anyway, interested in how you think about it.