### PR TITLE
Fix FPBIN

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -143,7 +143,7 @@ F1ACTIONCG="bash -c setColGui"
 BTS="backup-timestamp"
 DUMMYBIN="echo"
 STLAIDSIZE="12"
-FPBIN="/app/utils/${PROGCMD}/bin"
+FPBIN="/app/utils/bin"
 INFLATPAK=0
 
 ### default vars ###


### PR DESCRIPTION
Very minor fix, just to save you hitting `backspace` 10 times :joy: 

As per https://github.com/frostworx/steamtinkerlaunch/issues/27#issuecomment-1147819473

The flatpak binary directory is `/app/utils/bin`, not `/app/utils/steamtinkerlaunch/bin`. (STL itself should be located at `/app/utils/bin/steamtinkerlaunch` when running in a flatpak.)