### PR TITLE
Fix replay sorcery check

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -10804,7 +10804,7 @@ function useNyrna {
 function useReplay {
 	if [ -n "$RUN_REPLAY" ]; then
 		if [ "$RUN_REPLAY" -eq 1 ]; then
-			if "$PGREP" -f "$REPLAY" >/dev/null; then
+			if "$PGREP" -fx "$(which "REPLAY") >/dev/null; then
 				writelog "SKIP" "${FUNCNAME[0]} - '$REPLAY' already running - skipping"
 				RUN_REPLAY=0
 			else

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -10804,7 +10804,7 @@ function useNyrna {
 function useReplay {
 	if [ -n "$RUN_REPLAY" ]; then
 		if [ "$RUN_REPLAY" -eq 1 ]; then
-			if "$PGREP" -fx "$(which "REPLAY") >/dev/null; then
+			if "$PGREP" -fx "$(command -v "REPLAY")" >/dev/null; then
 				writelog "SKIP" "${FUNCNAME[0]} - '$REPLAY' already running - skipping"
 				RUN_REPLAY=0
 			else


### PR DESCRIPTION
Make sure it only looks for `replay-sorcery` and not  `replay-sorcery kms` Used `which` to get the path not sure if this is really necessary or even a good idea
fixes https://github.com/frostworx/steamtinkerlaunch/issues/489

First PR ever please let me know if anything can be done better (: