### PR TITLE
Steam Deck: Add ability to choose specific version of innoextract and downgrade innoextract from latest to 1.9-5

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -19270,6 +19270,11 @@ function steamdedeckt {
 		SDREPO="https://steamdeck-packages.steamos.cloud/archlinux-mirror/extra/os/x86_64/"
 
 		ARCHURL="https://archlinux.org/packages/community/x86_64"
+		ARCHARCHIVEURL="https://archive.archlinux.org/packages"
+		
+		INNOEXTRACTVERS="1.9-5"
+		INNOEXTRACTFILE="$INNOEXTRACT-$INNOEXTRACTVERS-x86_64.pkg.tar.zst"
+		INNOEXTRACTURL="$ARCHARCHIVEURL/i/$INNOEXTRACT/$INNOEXTRACTFILE"
 
 		ONSTEAMDECK=1
 
@@ -19300,10 +19305,10 @@ function steamdedeckt {
 		fi
 
 		if [ ! -f "$(command -v "$INNOEXTRACT")" ]; then
-			writelog "INFO" "${FUNCNAME[0]} - Downloading $INNOEXTRACT automatically from official Arch Linux URL '$ARCHURL'"
-			writelog "INFO" "${FUNCNAME[0]} - curl -Lq \"$ARCHURL/$INNOEXTRACT/download\" -o \"$STLDEPS/$INNOEXTRACT-latest-x86_64.pkg.tar.zst\""
-			LD_PRELOAD="/usr/lib/libcurl.so.4" curl -Lq "$ARCHURL/$INNOEXTRACT/download" -o "$STLDEPS/$INNOEXTRACT-latest-x86_64.pkg.tar.zst" 2>/tmp/curl.txt
-			tar xf "$STLDEPS/$INNOEXTRACT-latest-x86_64.pkg.tar.zst" -C "$STLDEPS"
+			writelog "INFO" "${FUNCNAME[0]} - Downloading $INNOEXTRACT version $INNOEXTRACTVERS automatically from official Arch Linux archive URL '$ARCHARCHIVEURL'"
+			writelog "INFO" "${FUNCNAME[0]} - curl -Lq \"$INNOEXTRACTURL\" -o \"$STLDEPS/$INNOEXTRACTFILE\""
+			LD_PRELOAD="/usr/lib/libcurl.so.4" curl -Lq "$INNOEXTRACTURL" -o "$STLDEPS/$INNOEXTRACTFILE" 2>/tmp/curl.txt
+			tar xf "$STLDEPS/$INNOEXTRACTFILE" -C "$STLDEPS"
 		fi
 
 		if [ -f "$(command -v "$INNOEXTRACT")" ]; then


### PR DESCRIPTION
The latest version of `innoextract` (currently 1.9-6) will not work on the Steam Deck as it needs a newer version of the `libboost_iostreams.so` library (needs: 1.79.0; currently on Steam Deck: 1.78.0) (mentioned in #272).

This PR adds the ability to choose a specific version of `innoextract` and downloads it from the [official Arch Linux archive](https://archive.archlinux.org/packages/i/innoextract/). 
The version of `innoextract` set to download in this PR is 1.9-5 as this is the last version that works with `libboost_iostreams.so.1.78.0`.

All modifications have been done in the `steamdedeckt` function and no variables have been changed (only added), so it should not affect other parts of the code and thus not affect people who are not on Steam Deck.

P.S. This is my first PR. Please be gentle :smile:.