### PR TITLE
ReShade: Fix detection of DLL conflicts between dxgi.dll and d3d9.dll

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7676,30 +7676,26 @@ function installReshade {
 
 		INSTDESTDIR="$SHADDESTDIR"
 
-		function maybedrop { # TODO remove?
-		# checking for previous dll conficts between $D3D47 and $RS_D9_DEST
-		if [ -f "$INSTDESTDIR/${RS_DX_DEST//.dll/.log}" ]; then
-			if grep -q "Another ${RESH} instance was already loaded" "$INSTDESTDIR/${RS_DX_DEST//.dll/.log}"; then
-				writelog "INFO" "${FUNCNAME[0]} - Found $RS_DX_DEST conflict with $RS_D9_DEST"
-				if [ -f "$INSTDESTDIR/$RS_D9_DEST" ]; then
-					writelog "INFO" "${FUNCNAME[0]} - Removing $RS_D9_DEST"
-					rm "$INSTDESTDIR/$RS_D9_DEST"
-				else
-					writelog "SKIP" "${FUNCNAME[0]} - $RS_D9_DEST not found"
-				fi
-				
-				if [ -z "$NOD3D9" ]; then
-					writelog "INFO" "${FUNCNAME[0]} - Blocking re-installation of '$RS_D9_DEST' by setting NOD3D9=1 in '$STLGAMECFG'"
-					updateConfigEntry "NOD3D9" "1" "$STLGAMECFG"
-					export NOD3D9=1
-				fi
+		# checking for previous dll conficts between $RS_DX_DEST and $RS_D9_DEST
+		# note: modern ReShade uses "ReShade_exenamehere.log", and old versions use "dxgi.log" (if ReShade dll is named dxgi.dll). we support both names.
+		RESHADE_CONFLICTS=$(find "$INSTDESTDIR" -maxdepth 1 \( -name "${RS_DX_DEST//.dll/.log}" -or -name "ReShade_*.log" \) -print0 | xargs -0 -r grep -l "Another ReShade instance was already loaded from" | wc -l)
+		if [ "$RESHADE_CONFLICTS" -ge 1 ]; then
+			writelog "INFO" "${FUNCNAME[0]} - Found $RS_DX_DEST conflict with $RS_D9_DEST"
+			if [ -f "$INSTDESTDIR/$RS_D9_DEST" ]; then
+				writelog "INFO" "${FUNCNAME[0]} - Removing $RS_D9_DEST"
+				rm "$INSTDESTDIR/$RS_D9_DEST"
 			else
-				writelog "INFO" "${FUNCNAME[0]} - No conflict found in old logfile ${RS_DX_DEST//.dll/.log}"
-			fi				
+				writelog "SKIP" "${FUNCNAME[0]} - $RS_D9_DEST not found"
+			fi
+
+			if [ -z "$NOD3D9" ]; then
+				writelog "INFO" "${FUNCNAME[0]} - Blocking re-installation of '$RS_D9_DEST' by setting NOD3D9=1 in '$STLGAMECFG'"
+				updateConfigEntry "NOD3D9" "1" "$STLGAMECFG"
+				export NOD3D9=1
+			fi
 		else
-			writelog "INFO" "${FUNCNAME[0]} - No old logfile ${RS_DX_DEST//.dll/.log} found"
+			writelog "INFO" "${FUNCNAME[0]} - No conflict found in old logfiles"
 		fi
-		}
 
 		if [ -n "$ARCHALTEXE" ] && [[ ! "$ARCHALTEXE" =~ ${DUMMYBIN}$ ]]; then
 			CHARCH="$ARCHALTEXE"


### PR DESCRIPTION
Closes #514.

- Efficiently scans the game's exe/dll folder (-maxdepth 1) for the legacy
  "dxgi.log" name and the modern "ReShade_exenamehere.log" name.

- If log files are found, they're passed into grep in "matching filenames"
  mode (-l), which does a quick scan that stops when a match is found.

- We use "wc -l" to count log files with conflicts (RESHADE_CONFLICTS).

- This accurately detects games where conflicts occurred between the
  two DLL files, for both old and new ReShade versions (log names).

- The rest of the code is the same as before. Note that we do the scan
  even if "$NOD3D9" is already set, just to ensure that the DLL gets
  deleted if it ever gets re-added by anything. The scan code is very
  fast, so it's fine to do the scan on every startup.