### PR TITLE
Slightly dirty fix for config "none" settings

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -8839,7 +8839,10 @@ function updateConfigEntry {
 						CFGVALUE="0"
 					fi	
 			
-					if [ "$CFGVALUE" == "DUMMY" ]; then
+					if [ "$CFGVALUE" == "DUMMY" ] || \
+						{ [ "$CFGVALUE" == "$NON" ] && \
+						{ [ "$CFGCAT" != "DXVK_LOG_LEVEL" ] && [ "$CFGCAT" != "DXVK_LOG_PATH" ] && [ "$CFGCAT" != "STL_PV_SHELL" ] ;};}
+					then
 						CFGVALUE=""
 					fi
 


### PR DESCRIPTION
### Reasoning
Currently anything in the UI that says "none" is set as such instead of left blank (besides a handful of options that like being "none").

It seems odd to populate numerous options with "none" when they can quite happily be left blank. It adds unnecessary byte bloat to configs (which can be numerous), and whenever checking options everything needs to be checked against both `$NON` and `<blank>`. If things are left blank where expected then options _should_ only need to be checked if they're blank.

### The fix
Is to check if an options in `updateConfigEntry` is "none" is to set it to <blank> instead, unless it's (currently) 3 special `$CFGCAT`s that can be blank.

It's slightly dirty, and hard to read, but I couldn't think how else to do it, besides just an extra if after the `DUMMY` part. That'd be vaguely more legible.

### Caveats
Every time an option that can be really set to "none" is added this bit of code would need to be remembered to be updated.