### PR TITLE
Fix Non-Steam Proton Games from Launching

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -16762,7 +16762,7 @@ function setProtonCmd {
 			
 			if [ -f "${RUNPROTON//\"/}" ]; then
 				writelog "INFO" "${FUNCNAME[0]} - Prepending Proton '$USEPROTON' (='${RUNPROTON//\"/}') to the command line '${GAMESTARTCMD[*]}'"
-				PROTSTARTCMD=("${RUNPROTON//\"/}" "$WFEAR")
+				PROTSTARTCMD=("${RUNPROTON//\"/}" "$WFEAR" "${GAMESTARTCMD[*]}")
 			else
 				writelog "INFO" "${FUNCNAME[0]} - Still don't have a usable proton executable in RUNPROTON '{RUNPROTON//\"/}')"
 				if [ "$HAVEINPROTON" -eq 1 ]; then


### PR DESCRIPTION
Non-Steam Proton games wouldn't launch with SteamTinkerLaunch. It seems the cause was a missing `"${GAMESTARTCMD[*]}"` argument when setting `PROTONSTARTCMD`. I discovered this by inspecting the logs and noticing that `GAMESTARTCMD[*]` had the correct value, but `PROTONSTARTCMD` was missing it for some reason. I'm not totally sure how the `setProtonCmd` function works or what functions are called around it, so I'm not sure why this was only broken for Non-Steam Proton games, but this seems to fix Non-Steam Proton games in my tests and doesn't break regular Steam Proton games. In fact, games seem to launch significantly faster now? Could just be placebo but I did compare a build from this branch and a build from master... Who knows :-)

Non-Steam Proton games tested:
- HoloCure
- Sonic P-06

Steam Proton games tested to ensure this change didn't break anything:
- Cookie Clicker (regular ol' Cookie Clicker with no tweaks)
- Old School RuneScape (this has a custom command to launch a native Linux third-party launcher called RuneLite, and also has custom commands like GameMode enabled)
- Fallout: New Vegas (modded to the hilt with MO2, and has a bunch of STL tweaks like DXVK Framerate Limiting, MangoHud and GameMode)

Steam Native games tested to be extra sure that this change didn't break anything:
- Terraria (native Linux game with `steamtinkerlaunch %command%`, no tweaks)
- Celeste (native Linux game with `steamtinkerlaunch %command%`, MangoHud enabled and a custom command line option set to force the game to use Vulkan instead of OpenGL)

I believe I covered as many basis as reasonably necessary to ensure this doesn't break anything, but I welcome all feedback and of course if there's something this change can potentially break let me know.

Thanks!