### PR TITLE
Only append GAMESTARTCMD to PROTNSTARTCMD if INGCMD is blank

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -16768,7 +16768,12 @@ function setProtonCmd {
 			
 			if [ -f "${RUNPROTON//\"/}" ]; then
 				writelog "INFO" "${FUNCNAME[0]} - Prepending Proton '$USEPROTON' (='${RUNPROTON//\"/}') to the command line '${GAMESTARTCMD[*]}'"
-				PROTSTARTCMD=("${RUNPROTON//\"/}" "$WFEAR" "${GAMESTARTCMD[*]}")
+
+				PROTSTARTCMD=("${RUNPROTON//\"/}" "$WFEAR")
+				if [ -z "${INGCMD[*]}" ]; then
+					writelog "INFO" "${FUNCNAME[0]} - INGCMD is blank (may be a Non-Steam Game), so appending GAMESTARTCMD to Proton start command"
+					PROTSTARTCMD=("${RUNPROTON//\"/}" "$WFEAR" "${GAMESTARTCMD[*]}")
+				fi
 			else
 				writelog "INFO" "${FUNCNAME[0]} - Still don't have a usable proton executable in RUNPROTON '{RUNPROTON//\"/}')"
 				if [ "$HAVEINPROTON" -eq 1 ]; then


### PR DESCRIPTION
Fixes #568.

Sonic Adventure 2 was failing to launch as a result of the changes in #560. The launch command ended up having the path to the game's launcher twice:

```
Thu Sep  1 21:38:30 BST 2022 INFO - launchSteamGame - Final outgoing start command: '/home/emma/.local/share/Steam/compatibilitytools.d/GE-Proton7-30/proton waitforexitandrun /run/media/emma/onigiri/Games/steamapps/common/Sonic Adventure 2/Launcher.exe /run/media/emma/onigiri/Games/steamapps/common/Sonic Adventure 2/Launcher.exe'
```

To fix this, I changed the logic from my PR #560 to only append `GAMESTARTCMD[*]` if `INGCMD[*]` is blank. For regular Steam games, `INGCMD` seems to always be set. However for Non-Steam games it does not ever seem to be set.

Example log line for Non-Steam Game HoloCure:

```
Thu Sep  1 23:15:53 BST 2022 INFO - launchSteamGame - Original incoming start command: ''
```

I guess however the path for Non-Steam games is sent is not checked by STL. A better fix might be to, somehow, properly parse the INGCMD for Non-Steam Games, but I'm not sure how to do this. I'm not even sure if I'm on the right track for it. What confuses me is why only some games (like SA2) have a duplicated path for their final outgoing command, even though all Steam games I have tested do actually have the correct incoming start command. Maybe it's correctly unset somewhere but not for Sonic Adventure 2, I'm not sure.

As this could be a potentially bigger issue I got a PR up as fast as I could to get some discussion and feedback. It's totally fine if this doesn't get merged as it is a bit of a "hacky" fix. Investigating how to fix the broader problem might take some time though, and this could serve as a fix in the interim. At least that's my logic for rushing to get this PR up. It's also my fault that this broke in the first place, so many apologies about that. I'll try to do better in future.

So essentially, I wanted to get a fix out for this issue to discuss the merits of merging a fix like this, and to maybe dig deeper into the root cause, because I could be way off. It also patches up the bug brought in by my "fix" without having to revert it. I believe on Steam Deck STL will update to the latest Git automatically, so there is a potential for this bug to affect a sizeable amount of users, and I wanted to get it at least temporarily patched ASAP.

If it's preferable to not have these kinds of fixes, or if it's not too hard to fix the root cause of the bug, we can toss this PR aside :slightly_smiling_face: 