### PR TITLE
fixes https://github.com/frostworx/steamtinkerlaunch/issues/567

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -16921,15 +16921,6 @@ function launchSteamGame {
 	if [ "$USEWINE" -eq 0 ]; then
 		# concatenate final game start command
 
-		if [ "$USEOBSCAP" -eq 1 ]; then
-			writelog "INFO" "${FUNCNAME[0]} - USEOBSCAP is enabled - preparing $OBSCAP command"
-			if [ -n "${FINALSTARTCMD[0]}" ]; then
-				FINALSTARTCMD=("${FINALSTARTCMD[@]}" "$OBSC")
-			else
-				FINALSTARTCMD=("$OBSC")
-			fi
-		fi
-
 		if [ -n "$GMR" ]; then
 			if [ -n "${FINALSTARTCMD[0]}" ]; then
 				FINALSTARTCMD=("${FINALSTARTCMD[@]}" "$GMR")
@@ -16950,6 +16941,15 @@ function launchSteamGame {
 			fi
 		fi
 
+		if [ "$USEOBSCAP" -eq 1 ]; then
+			writelog "INFO" "${FUNCNAME[0]} - USEOBSCAP is enabled - preparing $OBSCAP command"
+			if [ -n "${FINALSTARTCMD[0]}" ]; then
+				FINALSTARTCMD=("${FINALSTARTCMD[@]}" "$OBSC")
+			else
+				FINALSTARTCMD=("$OBSC")
+			fi
+		fi
+		
 		if [ "$USEMANGOHUD" -eq 1 ]; then
 			if [ "$MAHUARGS" != "$NON" ]; then
 				writelog "INFO" "${FUNCNAME[0]} - Exporting MANGOHUD_CONFIG with $MAHU arguments '$MAHUARGS'"


### PR DESCRIPTION
Move down the `OBSCAP` if to below game scope.  

TLDR,
**most** tools need to go after game scope's `--`  since the code is run top-down, by moving the code to append `obs-gamecapture` below the equivalent  game scope code, we can ensure that `obs-gamecapture` will be added after game scopes `--`