### PR TITLE
Remove 'waitforexitandrun' from ORGGCMD for Non-Steam Games

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v11.1.20220831"
+PROGVERS="v11.1.20220904"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -2149,7 +2149,11 @@ function setCustomGameVars {
 
 	while read -r ORGARG; do
 		mapfile -t -O "${#ORGGCMD[@]}" ORGGCMD <<< "$ORGARG"
-	done <<< "$(printf "%s\n" "$@")"	
+	done <<< "$(printf "%s\n" "$@")"
+	if [ "${ORGGCMD[0]}" == "$WFEAR" ]; then
+		# removing first ORGGCMD element as it is '$WFEAR'
+		unset "ORGGCMD[0]"
+	fi
 }
 
 function prepareGUI {
@@ -14459,6 +14463,10 @@ function prepareLaunch {
 	if [ -n "$GPFX" ]; then
 		writelog "INFO" "${FUNCNAME[0]} - Proton wineprefix '$GPFX'"
 	fi
+
+	if [ -z "${INGCMD[*]}" ] && [ -n "${ORGGCMD[*]}" ]; then
+		writelog "INFO" "${FUNCNAME[0]} - No INGCMD but valid ORGGCMD - May be Non-Steam game"
+	fi
 	writelog "INFO" "${FUNCNAME[0]} -------------------"
 	writelog "INFO" "${FUNCNAME[0]} - CreateGameCfg:"
 	createGameCfg
@@ -16768,7 +16776,7 @@ function setProtonCmd {
 			
 			if [ -f "${RUNPROTON//\"/}" ]; then
 				writelog "INFO" "${FUNCNAME[0]} - Prepending Proton '$USEPROTON' (='${RUNPROTON//\"/}') to the command line '${GAMESTARTCMD[*]}'"
-				PROTSTARTCMD=("${RUNPROTON//\"/}" "$WFEAR" "${GAMESTARTCMD[*]}")
+				PROTSTARTCMD=("${RUNPROTON//\"/}" "$WFEAR")
 			else
 				writelog "INFO" "${FUNCNAME[0]} - Still don't have a usable proton executable in RUNPROTON '{RUNPROTON//\"/}')"
 				if [ "$HAVEINPROTON" -eq 1 ]; then


### PR DESCRIPTION
Fixes #568.

Okay, a less-hacky and more substantial attempt at fixing Non-Steam Games from not launching. I'm hoping now I have a much more robust solution! :smile: 

I spent a few hours troubleshooting and I think I figured out the core of the issue. When a Non-Steam game is launching, its `ORGGCMD` is prefixed with `waitforexitandrun`. This means a Non-Steam Game executable path contained in `ORGGCMD` might look something like: `waitforexitandrun /home/gaben/Games/HalfLife3.exe`.

When running a regular Proton game from Steam, its `ORGGCMD` is **not** prefixed with `waitforexitandrun`.

## Problem Overview
I did some digging to try and find out why this is, and I came across two functions: `setGameVars` and `setCustomGameVars`. Doing some logging I figured out that, at least with the games and Non-Steam Games I tested, `setGameVars` is called for Steam Proton games, and `setCustomGameVars` is called for Non-Steam Games. The reason for this is because of this block pretty much at the very bottom of the main function:

```bash
# [...]
if [ -n "$SteamAppId" ] && [ "$SteamAppId" -eq "0" ]; then
    if grep -q "\"$1\"" <<< "$(sed -n "/^#STARTCMDLINE/,/^#ENDCMDLINE/p;/^#ENDCMDLINE/q" "$0" | grep if)"; then
        writelog "INFO" "${FUNCNAME[0]} - Seems like a '$PROGCMD'-internal command was started - checking the command line"
        commandline "$@"
    else
        setCustomGameVars "$@"
        if [ -n "$ISGAME" ]; then
            if [ "$ISGAME" -eq 2 ] || [ "$ISGAME" -eq 3 ]; then
                prepareLaunch
            fi
        else
            writelog "ERROR" "${FUNCNAME[0]} - Unknown command '$*'" "E"
        fi
    fi
# [...]
```

This block checks if a game is missing a Steam AppID, which a Non-Steam Proton game is going to be missing a "proper" AppID. So when STL determines that it's dealing with a game without an AppID, it calls `setCustomGameVars`, and then if it can determine that we're dealing with an actual Non-Steam Game, it runs through the rest of the launch process.

 There is a block below this which gets called when a Proton game launches, which calls `setGameVars` (note: not complete block, just an illustration):

```bash
elif grep -q "$SAC" <<< "$@" || grep -q "$L2EA" <<< "$@"; then
    if grep -q "update" <<< "$@" || grep -q "^play" <<< "$@" ; then
        commandline "$@"
    else
        setGameVars "$@"
        # [...]
    fi
fi
```

So in summary, Non-Steam Proton Games call `setCustomGameVars`, and Steam Proton games called `setGameVars`. It seems to make sense too, as attempting to call `setGameVars` when running a Non-Steam Game doesn't work and causes some other issues (game name shows up as Placeholder for one). The naming also makes sense too that `setCustomGameVars` would correspond to Non-Steam Games.

The main difference in these functions is that `setGameVars` properly strips the `waitforexitandrun` from the `ORGGCMD`, but `setCustomGameVars` doesn't. Compare this part of each function:

### `setGameVars`
```bash
# what is left now is the game executable and its command line arguments - splitting

FOUNDORGGCMD=0
while read -r ORGARG; do
    if [ "$FOUNDORGGCMD" -eq 0 ]; then
        mapfile -t -O "${#ORGGCMD[@]}" ORGGCMD <<< "$ORGARG"
        if [[ "$ORGARG" =~ $GP ]]; then
            FOUNDORGGCMD=1
        fi
    else
        mapfile -t -O "${#ORGCMDARGS[@]}" ORGCMDARGS <<< "$ORGARG"
    fi
done <<< "$(printf "%s\n" "${ORGFGCMD[@]}")"

if [ "${ORGGCMD[0]}" == "$WFEAR" ]; then
    # removing first ORGGCMD element as it is '$WFEAR'
    unset "ORGGCMD[0]"
fi
```

### `setCustomGameVars`
```bash
while read -r ORGARG; do
    mapfile -t -O "${#ORGGCMD[@]}" ORGGCMD <<< "$ORGARG"
done <<< "$(printf "%s\n" "$@")"
```

There is no check for `waitforexitandrun` at the end of the Non-Steam Game `ORGGCMD` setting. And I believe this is the heart of the problem, as this causes problems somewhere in the `launchSteamGame` function. Unfortunately I'm not totally sure _where_, but as this part of the code does a lot of checks and sets up the actual final start command, I would guess that having `waitforexitandrun` still in the `ORGGCMD` causes something to trip. Maybe it thinks something is already set that shouldn't be? Since I believe `waitforexitandrun` is appended somewhere else before the game starts.

So by not removing the `waitforexitandrun` from the `ORGGCMD`, we end up not actually appending the game executable to the final launch command, it ends up being something like `/home/gaben/.local/share/Steam/compatibilitytools.d/GE-Proton7-31/proton waitforexitandrun`.

## Solution (?)
To fix this, I just took the `if` check from `setGameVars` that removes `waitforexitandrun` from the start of the `ORGGCMD` array. The `setCustomGameVars` function now looks like:

```bash
while read -r ORGARG; do
    mapfile -t -O "${#ORGGCMD[@]}" ORGGCMD <<< "$ORGARG"
done <<< "$(printf "%s\n" "$@")"
if [ "${ORGGCMD[0]}" == "$WFEAR" ]; then
    # removing first ORGGCMD element as it is '$WFEAR'
    unset "ORGGCMD[0]"
fi
```

It pretty much mirrors what we have in `setGameVars`, but the logic for setting up the `ORGGCMD` array was already there and less complex than `setGameVars`, so I didn't touch it. All this does is take `waitforexitandrun` out of `ORGGCMD`, and this seems to fix Non-Steam Games from not working.

## Testing
I tested with the Non-Steam Game HoloCure. The Steam games I tested with were Cookie Clicker, Sonic Adventure 2, Terraria and Celeste.

I tested running Steam games and Non-Steam games with MangoHud, GameMode, and GameScope, and they still work. Custom commands for Steam games and Non-Steam games seem to still work too!

I had a problem since PR #560 that broke Sonic Adventure 2, but this PR fixes both Non-Steam Games and Sonic Adventure 2 from not launching.

From my tests, this solution seems more solid than my other two attempts, and seems to address the core of the issue.

## Conclusion
I tried to take a more well thought out approach to fixing this problem and I'm hoping I got to the heart of it. I couldn't find out if there was a specific reason that `waitforexitandrun` was not stripped from Non-Steam games, maybe it just wasn't there initially on the original game launch args. It also doesn't seem to break anything, and to me the solution makes a lot more sense than the other two, which were missing the overarching problem, which as a result of my research with this PR seems to be a result of `ORGGCMD` having `waitforexitandrun` in it.

I don't think we need the same complex logic that `setGameVars` has for setting up the `ORGGCMD` array, the solution in place at the moment seems to work.

If this is still undesirable, we can have a discussion about it and see if we can get closer to the heart of the problem.

Thanks! Fingers cross that third time's the charm haha :crossed_fingers: 