### PR TITLE
Open Crash Guesser Even If Playtime Is Equal To Crash Guess Time

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -15178,7 +15178,7 @@ function checkPlayTime {
 	elif [ -z "$1" ]; then
 		writelog "INFO" "${FUNCNAME[0]} - The game was not even started"
 	else
-		if [ -n "$CRASHGUESS" ] && [ "$1" -lt "$CRASHGUESS" ]; then
+		if [  -n "$CRASHGUESS" ] && [ "$1" -le "$CRASHGUESS" ]; then
 			writelog "INFO" "${FUNCNAME[0]} - The game stopped after '$1' seconds - opening CrashGuess Requester"
 			steamdeckControl
 			fixShowGnAid


### PR DESCRIPTION
Checks if the play time is **equal to** `$CRASHGUESS`.

While looking through the logs for a currently open issue, I noticed the line:

```
Fri  2 Sep 09:43:07 CEST 2022 INFO - checkPlayTime - Playtime '0' was longer than CRASHGUESS '0', not opening the requester
```

When investigating, I found STL only checks if the time played is *less than* the crash guess timer, not equal to it. This is probably because in most cases it'll never really be equal, but in the case of the log I was looking through, it was.

Having this will make it clearer when a game has crashed and prevent silent crashing, which is probably not ideal for users. It also helps on systems that don't show the notifier (e.g., Steam Deck), as it gives some visual feedback that the game has crashed.