### PR TITLE
Fix logic for fetching MO2 and Vortex version

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v11.1.20220920"
+PROGVERS="v11.1.20220921"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -2489,7 +2489,7 @@ function setDefaultCfgValues {
 		if [ -z "$DL_D3D47_64" ]						; then	DL_D3D47_64="https://lutris.net/files/tools/dll/$D3D47"; fi
 		if [ -z "$DL_D3D47_32" ]						; then	DL_D3D47_32="http://dege.freeweb.hu/dgVoodoo2/bin/D3DCompiler_47.zip"; fi
 		if [ -z "$RESHADEDLURL" ]						; then	RESHADEDLURL="https://reshade.me/downloads"; fi
-		if [ -z "$VORTEXRELURL" ]						; then	VORTEXRELURL="$GHURL/Nexus-Mods/${VTX^}/releases"; fi
+		if [ -z "$VORTEXPROJURL" ]						; then  VORTEXPROJURL="$GHURL/Nexus-Mods/${VTX^}"; fi
 		if [ -z "$DXVKURL" ]							; then	DXVKURL="$GHURL/doitsujin/dxvk"; fi
 		if [ -z "$XLIVEURL" ]							; then	XLIVEURL="$GHURL/ThirteenAG/Ultimate-ASI-Loader/releases/download/v4.61/Ultimate-ASI-Loader.zip"; fi
 		if [ -z "$STASSURL" ]							; then	STASSURL="https://steamcdn-a.akamaihd.net/steam/apps"; fi
@@ -2498,7 +2498,7 @@ function setDefaultCfgValues {
 		if [ -z "$X64DBGURL" ]							; then	X64DBGURL="$GHURL/x64dbg/x64dbg/releases/tag/snapshot";fi
 		if [ -z "$STEAMGRIDDBAPI" ]						; then	STEAMGRIDDBAPI="https://www.steamgriddb.com/api/v2/grids/steam";fi
 		if [ -z "$CONTYRELURL" ]						; then	CONTYRELURL="$GHURL/Kron4ek/Conty/releases"; fi
-		if [ -z "$MO2DLURL" ]							; then	MO2DLURL="$GHURL/ModOrganizer2/modorganizer/releases"; fi
+		if [ -z "$MO2PROJURL" ]							; then  MO2PROJURL="$GHURL/ModOrganizer2/modorganizer"; fi
 		if [ -z "$CW_KRON4EK" ]							; then	CW_KRON4EK="$GHURL/Kron4ek/Wine-Builds/releases"; fi
 		if [ -z "$IGCSZIP" ]							; then	IGCSZIP="$GHURL/FransBouma/InjectableGenericCameraSystem/releases/download/IGCSInjector_102/IGCSInjector_v102.zip"; fi
 		if [ -z "$UUUURL" ]								; then	UUUURL="https://framedsc.github.io/GeneralGuides/universal_ue4_consoleunlocker.htm#downloading-the-uuu"; fi
@@ -2815,8 +2815,8 @@ function saveCfg {
 			echo "DXVKURL=\"$DXVKURL\""				
 			echo "## ${RESH} DL URL"
 			echo "RESHADEDLURL=\"$RESHADEDLURL\""
-			echo "## ${VTX^} DL URL"
-			echo "VORTEXRELURL=\"$VORTEXRELURL\""
+			echo "## ${VTX^} Project URL"
+			echo "VORTEXPROJURL=\"$VORTEXPROJURL\""
 			echo "## Xlive DL URL"
 			echo "XLIVEURL=\"$XLIVEURL\""
 			echo "## Steam Asset URL"
@@ -2831,8 +2831,8 @@ function saveCfg {
 			echo "STEAMGRIDDBAPI=\"$STEAMGRIDDBAPI\""
 			echo "## Conty DL URL"
 			echo "CONTYRELURL=\"$CONTYRELURL\""
-			echo "## Mod Organizer 2 DL URL"
-			echo "MO2DLURL=\"$MO2DLURL\""
+			echo "## Mod Organizer 2 Project URL"
+			echo "MO2PROJURL=\"$MO2PROJURL\""
 			echo "## $DPRS DL URL"
 			echo "DPRSRELURL=\"$DPRSRELURL\""
 			echo "## $DEPS URL"
@@ -4975,7 +4975,7 @@ function AllSettingsEntriesDummyFunction {
 --field="     $GUI_DL_D3D47_64!$DESC_DL_D3D47_64 ('DL_D3D47_64')" "${DL_D3D47_64/#-/ -}" `#CAT_Urls` `#MENU_URL` \
 --field="     $GUI_DL_D3D47_32!$DESC_DL_D3D47_32 ('DL_D3D47_32')" "${DL_D3D47_32/#-/ -}" `#CAT_Urls` `#MENU_URL` \
 --field="     $GUI_RESHADEDLURL!$DESC_RESHADEDLURL ('RESHADEDLURL')" "${RESHADEDLURL/#-/ -}" `#CAT_Urls` `#MENU_URL` \
---field="     $GUI_VORTEXRELURL!$DESC_VORTEXRELURL ('VORTEXRELURL')" "${VORTEXRELURL/#-/ -}" `#CAT_Urls` `#MENU_URL` \
+--field="     $GUI_VORTEXRELURL!$DESC_VORTEXRELURL ('VORTEXPROJURL')" "${VORTEXPROJURL/#-/ -}" `#CAT_Urls` `#MENU_URL` \
 --field="     $GUI_DXVKURL!$DESC_DXVKURL ('DXVKURL')" "${DXVKURL/#-/ -}" `#CAT_Urls` `#MENU_URL` \
 --field="     $GUI_XLIVEURL!$DESC_XLIVEURL ('XLIVEURL')" "${XLIVEURL/#-/ -}" `#CAT_Urls` `#MENU_URL` \
 --field="     $GUI_STASSURL!$DESC_STASSURL ('STASSURL')" "${STASSURL/#-/ -}" `#CAT_Urls` `#MENU_URL` \
@@ -4984,7 +4984,7 @@ function AllSettingsEntriesDummyFunction {
 --field="     $GUI_X64DBGURL!$DESC_X64DBGURL ('X64DBGURL')" "${X64DBGURL/#-/ -}" `#CAT_Urls` `#MENU_URL` \
 --field="     $GUI_STEAMGRIDDBAPI!$DESC_STEAMGRIDDBAPI ('STEAMGRIDDBAPI')" "${STEAMGRIDDBAPI/#-/ -}" `#CAT_Urls` `#MENU_URL` \
 --field="     $GUI_CONTYRELURL!$DESC_CONTYRELURL ('CONTYRELURL')" "${CONTYRELURL/#-/ -}" `#CAT_Urls` `#MENU_URL` \
---field="     $GUI_MO2DLURL!$DESC_MO2DLURL ('MO2DLURL')" "${MO2DLURL/#-/ -}" `#CAT_Urls` `#MENU_URL` \
+--field="     $GUI_MO2DLURL!$DESC_MO2DLURL ('MO2PROJURL')" "${MO2PROJURL/#-/ -}" `#CAT_Urls` `#MENU_URL` \
 --field="     $GUI_DPRSRELURL!$DESC_DPRSRELURL ('DPRSRELURL')" "${DPRSRELURL/#-/ -}" `#CAT_Urls` `#MENU_URL` \
 --field="     $GUI_DEPURL!$DESC_DEPURL ('DEPURL')" "${DEPURL/#-/ -}" `#CAT_Urls` `#MENU_URL` \
 --field="$(spanFont "$GUI_OPTSVR" "H")":LBL "SKIP" `#CAT_VR` `#HEAD_VR` `#MENU_GAME` `#MENU_GLOBAL`  \
@@ -11946,6 +11946,29 @@ function installDotNet {
 	writelog "INFO" "${FUNCNAME[0]} - Stopped $DOTN$DNVER install - check $ILOG"
 }
 
+#### MO2 + Vortex ####
+# NOTE: This was written with MO2 and Vortex in mind
+# It relies on projects having proper releases and tagging
+# It may need tweaking if this is used for other projects in future or might require an entirely new function
+function getLatestGitHubExeVer {
+    SETUPNAME="$1"
+    PROJURL="$2"
+
+    RELEASESURL="${PROJURL}/releases"
+    EXPANDEDASSETSURL="${RELEASESURL}/expanded_assets"
+    TAGSURL="${PROJURL}/tags"
+
+    TAGSGREP="${RELEASESURL#"$GHURL"}/tag"
+
+    LATESTTAG="$("$WGET" -q "${TAGSURL}" -O - 2> >(grep -v "SSL_INIT") | grep -m1 "$TAGSGREP" | grep -oE "${TAGSGREP}[^\"]+")"
+    LATESTVER="${LATESTTAG##*/}"
+
+    LATESTRELEASEURL="${EXPANDEDASSETSURL}/${LATESTVER}"
+
+    SETUPFILE="$("$WGET" -q "${LATESTRELEASEURL}" -O - 2> >(grep -v "SSL_INIT") | grep "exe" | grep -m1 "$SETUPNAME" | grep -oE "${SETUPNAME}[^\"]+")"
+    echo "${SETUPFILE}"
+}
+
 #### VORTEX START: ####
 
 function addVortexStage {
@@ -12048,7 +12071,7 @@ function setVortexDLMime {
 function getLatestVortVer {
 	VSET="$VTX-setup"
 	writelog "INFO" "${FUNCNAME[0]} - Search for latest ${VTX^} stable Release"
-	VORTEXSETUP="$("$WGET" -q "${VORTEXRELURL}/latest" -O - 2> >(grep -v "SSL_INIT") | grep -m1 "$VSET" | grep -oE "${VSET}[^\"]+")"
+	VORTEXSETUP="$(getLatestGitHubExeVer "$VSET" "$VORTEXPROJURL")"
 	writelog "INFO" "${FUNCNAME[0]} - Found '$VORTEXSETUP'"
 	echo "VORTEXSETUP=$VORTEXSETUP" > "$VTST"
 }
@@ -12068,7 +12091,7 @@ function dlLatestVortex {
 			VVRAW="$(grep -oP "${VSET}-\K[^X]+" <<< "$VORTEXSETUP")"
 			VORTEXVERSION="${VVRAW%.exe}"
 			
-			DLURL="$VORTEXRELURL/download/v$VORTEXVERSION/$VORTEXSETUP"
+			DLURL="$VORTEXPROJURL/releases/download/v$VORTEXVERSION/$VORTEXSETUP"
 			# no idea how the sha512 is formatted in the yaml, so simply checking the size
 			DLCHK="stat"
 			INCHK="$("$WGET" -q "${DLURL//$VORTEXSETUP/latest.yml}" -O - 2> >(grep -v "SSL_INIT") | grep "size:" | gawk -F': ' '{print $2}')"
@@ -13059,8 +13082,8 @@ function askVortex {
 function getLatestMO2Ver {
 	MO2SET="Mod.Organizer"
 
-	writelog "INFO" "${FUNCNAME[0]} - Search for latest '$MO2SET' Release under '$MO2DLURL'"
-	MO2SETUP="$("$WGET" -q "${MO2DLURL}" -O - 2> >(grep -v "SSL_INIT") | grep "exe" | grep -m1 "$MO2SET" | grep -oE "${MO2SET}[^\"]+")"
+	writelog "INFO" "${FUNCNAME[0]} - Search for latest '$MO2SET' Release under '$MO2PROJURL'"
+	MO2SETUP="$(getLatestGitHubExeVer "$MO2SET" "$MO2PROJURL")"
 	if [ -n "$MO2SETUP" ]; then
 		writelog "INFO" "${FUNCNAME[0]} - Found '$MO2SETUP'"
 	else
@@ -13077,7 +13100,7 @@ function dlLatestMO2 {
 		if [ ! -f "$MO2SPATH" ]; then
 			MO2VRAW="$(grep -oP "${MO2SET}-\K[^X]+" <<< "$MO2SETUP")"
 			MO2VERSION="${MO2VRAW%.exe}"
-			DLURL="$MO2DLURL/download/v$MO2VERSION/$MO2SETUP"
+			DLURL="$MO2PROJURL/releases/download/v$MO2VERSION/$MO2SETUP"
 			writelog "INFO" "${FUNCNAME[0]} - Downloading $MO2SETUP to $MO2DLDIR from '$DLURL'"
 			
 			if [ -n "$1" ]; then


### PR DESCRIPTION
Fixes #591, #589. Will be needed for #540.

## Problem 
GitHub changed how assets are loaded on the releases page, they are loaded after the page with lazy loading, so we can't `wget` on the releases page and get the executable when trying to get the executable version and name for MO2 and Vortex Mod Manager. This means MO2 and Vortex can't be downloaded, as STL doesn't catch their version. `MO2SETUP` and `VORTEXSETUP`, which hold the setup executable, end up blank since the `wget` code fails.

## Solution
Instead, we can get the latest tag version from the release tags page and get the release executable name from the `expanded_assets` page for that version. On this page, we can use the previous logic to get the setup executable name.

This solution uses a generic function that works for both MO2 and Vortex. This function only changes how we fetch the latest version for these tools, the actual download logic is the same since that URL did not change.

## How This Works
(adding this in an edit because I forgot to include it initially in my rush to get this up, oops!)
Basically, the way we get the version now is as follows. See my [comment with an initial attempt](https://github.com/frostworx/steamtinkerlaunch/issues/591#issuecomment-1252724630) at getting this working and [my initial generic function attempt](https://github.com/frostworx/steamtinkerlaunch/issues/591#issuecomment-1252758125) for some background/context on how this solution came to be.

We have a new function called `getLatestGitHubExeVer`. This function takes two inputs: The exe name (`SETUPNAME`) to look for, and the project URL (`PROJURL`). This is why the two new project URLs were added, they were added to be passed to this function.

We check the tags page (e.g., for MO2 this is https://github.com/ModOrganizer2/modorganizer/tags) and grep all of the elements that have a specific tag link. For example with MO2 this would be getting all elements on the page that have `/ModOrganizer2/modorganizer/releases/tag`. We take the first one which should always be the latest **release** (we are only looking for tags associated with a **release**, and in the case these two projects, this seems to work as we don't get any MO2 development tags). 

There were probably other ways to check this but the tags page seemed to return the least amount of data, so I chose that method.

This will return a bunch of elements that have paths that for MO2 might look like `/ModOrganizer2/modorganizer/releases/tag/v2.4.4`, then one with `v2.4.3`, `v2.4.2`, and so on. We strip out the version from these paths and we build a path to the `expanded_assets` URL for that version. This is where GitHub pulls the Assets information that it displays on the releases page. For example, see this URL for MO2: https://github.com/ModOrganizer2/modorganizer/releases/expanded_assets/v2.4.4

We get the `/ModOrganizer2/modorganizer/releases/tag` path by using the `RELEASESURL` variable and stripping off the `GHURL` prefix, then adding `/tag` to the end. That way it doesn't have to be hardcoded if the URL ever changes.

We build the URL to the `expanded_assets` release page with the version because the relevant version needs to be put onto the end of that path. So in future when `2.4.5` comes out, we'll get the latest version from the tags and then we'll build a path for the `expanded_assets/v2.4.5` download.

Then we use the previous existing logic that was used to get the setup executable from the releases page, to get the setup executable from the `expanded_assets` page.

Hope that explanation made sense, feel free to ask me to elaborate. Sometimes I'm not very good at explaining it in words so if you need more info please ask! 

## Concerns 
This PR adds two new URLs, which are the project URLs for MO2 and Vortex. Will these new URLs automatically populate for users when they update? No existing URLs should've been altered, the URLs are new and added.

If I need to do any work to make sure they populate for the user, please let me know. I want this change to be as simple for users as updating STL :smiley: 

A couple of people have tried out this patch already and it seems to work for them.

<hr>

I am very inexperienced with Bash, so please don't hesitate to call out anything that could be done better. The new function was kind of hacked together from a test script I made while drinking coffee. 

I wanted to get some sort of fix out ASAP for this bug and "it works on my machine"(TM). Vortex was able to start installing and MO2 got to the point where it asked me to create an instance and choose my games.

As usual, all feedback is appreciated. Thanks! :smile: 

P.S. It was talked about before but soon after this PR or a similar sort of fix for this issue is merged, maybe we should think about rolling a new release. I only say this because fixing this issue is slightly-medium-priority in my mind, it might be good to get it out in stable for users ASAP.