### PR TITLE
Add 'Valheim' to MO2 games list

### DIFF
--- a/misc/mo2games.txt
+++ b/misc/mo2games.txt
@@ -35,4 +35,5 @@
 "The Witcher 3 Wild Hunt";"292030";"The Witcher 3: Wild Hunt";"witcher3"
 "The Witcher 3 Wild Hunt";"499450";"The Witcher 3: Wild Hunt";"witcher3"
 "X-Plane 11";"269950";"X-Plane 11";"xplane11"
+"Valheim";"892970";"valheim";"valheim"
 "Zeus and Poseidon";"566050";"Zeus and Poseidon";"zeusandposeidon"


### PR DESCRIPTION
On March 20th, Valheim was added to the list of MO2 wiki under the list of games with basic support: https://github.com/ModOrganizer2/modorganizer/wiki/Game-Support/_history

This file was discussed recently in an issue I think, about how it should be updated periodically to include new games. I'm not *totally* sure if anything else is needed for this game to be """supported""" so to speak, so please let me know if I have to do any additional work.