### PR TITLE
Fix getExeFromID when GAMEEXE is not available

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6728,10 +6728,19 @@ function getExeFromID {
 		echo "A Game ID is required as argument"
 	else
 		if [ -f "$GEMETA/${1}.conf" ]; then
-			grep "^GAMEEXE" "$GEMETA/${1}.conf" | cut -d '=' -f2
-		else
-			echo "No Title found for '$1'"
+			# Some games might only have "EXECUTABLE" in their meta conf file
+			EXE="$(grep "^EXECUTABLE" "$GEMETA/${1}.conf" | cut -d '"' -f2)"
+			if [ -z "${EXE}" ]; then
+				EXE="$(grep "^GAMEEXE" "$GEMETA/${1}.conf" | cut -d '"' -f2)"
+			fi
+			
+			if [ ! -z "${EXE}" ]; then
+				echo $EXE
+				return
+			fi
 		fi
+
+		echo "No Executable or SteamTinkerLaunch file found for '$1'"
 	fi
 }
 


### PR DESCRIPTION
Currently, `getExeFromID` searches the game's meta folder for the `GAMEEXE` value. Not all games have this, most of my game meta configs have `EXECUTABLE`.

This PR sets the default variable that we search on to `EXECUTABLE`, with a fallback to `GAMEEXE` if no game is found with this.

I also did a minor change to how the error message is returned. Currently the exe not found error message only shows up if the game config folder isn't found. This PR changes it so we show this error message if we can't find the game exe *or* if we're unable to find the STL game meta file. The error message was also slightly tweaked to reflect this.

In my tests this fixes the issue for my games. Not sure if I did this in the cleanest way so all feedback welcome :smile: 