### PR TITLE
Use NAME instead of GAMENAME for getTitleFromId

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6712,8 +6712,8 @@ function getTitleFromID {
 		echo "A Game ID is required as argument"
 	else
 		if [ -f "$GEMETA/${1}.conf" ]; then
-			if grep -q "^GAMENAME" "$GEMETA/${1}.conf"; then
-				grep "^GAMENAME" "$GEMETA/${1}.conf" | cut -d '=' -f2
+			if grep -q "^NAME" "$GEMETA/${1}.conf"; then
+				grep "^NAME" "$GEMETA/${1}.conf" | cut -d '"' -f2
 			else
 				getAppInfoData "$1" "name"
 			fi


### PR DESCRIPTION
Usually `NAME` and `GAMENAME` are the same, but for some titles like Sonic Origins, `GAMENAME` displays "SonicOrigins" whereas `NAME` displays "Sonic Origins".  For other titles like "Fallout: New Vegas", `GAMENAME` doesn't have the colon. This PR changes `getTitleFromID` to use `NAME` instead of `GAMENAME`. It also changes the `cut` delimiter to use a double-quote, as this removes a case where some game names are returned with quotes and some aren't. In my tests this removes games returning with double quotes, they all return cleanly without them.

Some examples:

| `GAMENAME` (existing) | `NAME` (This PR) |
| ----- | ----- |
| SonicOrigins | Sonic Origins |
| Fallout New Vegas | Fallout: New Vegas |
| GUILTY GEAR STRIVE | GUILTY GEAR -STRIVE- |
| DOOMEternal | DOOM Eternal |

This is a very, very minor cosmetic change that shouldn't break anything. I had a look around to see where and how `getTitleFromID` is used around the codebase and it looks like it's only used for this function and for listing installed games. As far as I know every game should have both `GAMENAME` and `NAME`, it's just that `NAME` tends to look a little prettier :smile: 