### PR TITLE
Add uninstall to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,12 @@ install:
 	install -Dm644 "misc/steamtinkerlaunch.desktop" -t "$(PREFIX)/share/applications"
 	install -Dm644 "misc/steamtinkerlaunch.svg" -t "$(PREFIX)/share/icons/hicolor/scalable/apps"
 
+uninstall:
+	rm -rf "${PREFIX}/share/icons/hicolor/scalable/apps/misc/steamtinkerlaunch.svg"
+	rm -rf "${PREFIX}/share/applications/misc/steamtinkerlaunch.desktop"
+	rm -rf "${PREFIX}/share/doc/steamtinkerlaunch"
+
+	rm -rf "${PREFIX}/share/steamtinkerlaunch"
+
+	rm -f "${PREFIX}/bin/steamtinkerlaunch"
+


### PR DESCRIPTION
This PR attempts to add some very basic "uninstall" steps to the Makefile to allow for running `sudo make uninstall`. It essentially does the reverse of the install process to accomplish this.

I haven't ever touched a Makefile before this but I've had this idea for a while, and I had a look around online to see if I could find any examples of how to do this "right". Turns out I couldn't find very much at all on this! So my apologies if this is incorrect.

I initially had the idea for this PR all the way back when #483. After the comments there I weighed up in my mind whether or not this would be beneficial and worth investigating. After some research it seemed like this was the correct approach, but in-between various other things I kept this branch around and still weighed up 1) is this the right approach, and 2) is it worth implementing. Given the comments, I understand this PR might have a lower chance of being accepted.

I agree with everything laid out in the response, that installing from a Makefile should be a last resort. I also entirely think that uninstallation is *one of the many reasons we have package managers*, they do this job for us. I also agree that maintenance cost of uninstall blocks is something to take into consideration, which I tried my best to do for this PR.

The approach I took with the uninstall steps was to mirror the install steps (removing files first that are added by `install` last), and to avoid specifying removing *specific* files. This way we just remove the folders. This means we don't have to specify deleting, say, the `misc` folder in `/usr/share/steamtinkerlaunch`, we just remove *everything* under `/usr/share/steamtinkerlaunch`. I also took the consideration of hardcoding sudo on board, the Makefile does not enforce sudo itself though likely most systems will need `sudo make uninstall`.

My reason for going ahead and opening the PR anyway is that even if installing from a Makefile should be a last resort, I still think this would be a nice feature to have. I also think the maintenance cost for this should be relatively low. My hope is that this approach to the uninstall section is more maintainable and should rarely need updating, unless SteamTinkerLaunch writes to a new system folder with install. But if SteamTinkerLaunch ever adds a new folder to `/usr/share/steamtinkerlaunch` or something like that, no changes should have to be made to the uninstall block. From looking around I'm not sure which new system folders STL would ever need to write to, it would probably just add extra items into the `/usr/share` folder.

It might also be useful to have this uninstall block for users that want to "migrate" how they installed SteamTinkerLaunch. For example users on a distro without an STL package and that installed manually, but that want to migrate to Flatpak Steam, or a local install through ProtonUp-Qt.

I have a lot of stuff I do locally with STL just to mess around and learn, and this was an experiment to learn about uninstall blocks. I totally get it if the maintenance cost of this change is still too great or if it's unwanted for any other reason. Since it started as just a little "learning exercise" so to speak, I still think I got something out of working on this. And any feedback on how to add uninstall steps to Makefiles would be great if this is wrong or could be improved.

Thanks! 