### PR TITLE
Write out GAMEID to meta file for native Linux games

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -19145,7 +19145,7 @@ function closeSTL {
 	rm "$STLSHM/lola-*.txt" 2>/dev/null
 
 	# only useful for win games or games started outside steam:
-	if [ "$STLPLAY" -eq 1 ] || { [ "$ISGAME" -eq 2 ] && [ "$USEWINE" -eq 0 ];}; then
+	if [ "$STLPLAY" -eq 1 ] || { [ "$ISGAME" -eq 2 ] || [ "$ISGAME" -eq 3 ] && [ "$USEWINE" -eq 0 ];}; then
 		writeLastRun
 		storeMetaData "$AID" "$GN" "$GPFX" "$EFD"
 	fi


### PR DESCRIPTION
Resolves the initial issue for #604 

When I first opened the above issue, the reason was that the old code for getting a game's AppID relied (kinda) on the `GAMEID` field in the game's meta file. #607 changed this, so the original problem was resolved because now native Linux games are found. However the original "problem" I guess you could say still remained, `GAMEID` wasn't written out.

It doesn't seem like this is causing any problems but for parity I thought it would be good to write out the `GAMEID` for native Linux games as well. That's what this PR achieves.

The reason it wasn't being written out before is because before writing to the meta file, STL was only checking if `"$ISGAME" -eq 2`, where `2` is a Proton game. I added a check for `"$ISGAME" -eq 3`, as `3` seems to correspond to native games.

I tested a couple of native games (Portal, Factorio) and they worked. I can't see why this would potentially cause any problems and in my tests it works fine even if it's only an incredibly minor change.

Thanks! :smile: 