### PR TITLE
Fix shellcheck warnings in #607

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6705,23 +6705,20 @@ function getIDFromTitle {
 	else
 		# Search for all meta files with a partial match for their `NAME` field
 		# Search on `NAME` primarily, fallback to `GAMENAME`
-		SAVEIFS=$IFS
-		IFS=$'\n'
-		MATCHES=( $(grep -i "^NAME=.*.$1" "$GEMETA" -R) )
-		if [ -z "${MATCHES}" ]; then
-			MATCHES=( $(grep "^GAMENAME=.*.$1" "$GEMETA" -R) )
+		mapfile -t MATCHES < <(grep -i "^NAME=.*.$1" "$GEMETA" -R)
+		if [ -z "${MATCHES[*]}" ]; then
+			mapfile -t MATCHES < <(grep -i "^GAMENAME=.*.$1" "$GEMETA" -R)
 		fi
-		IFS=$SAVEIFS
-		
+
 		# Echo all matches in format "AppID (Game Name)"
-		if [ ! -z "${MATCHES}"  ]; then
+		if [ -n "${MATCHES[*]}"  ]; then
 			for i in "${MATCHES[@]}"
 			do
 				MATCH_AID="$( echo "${i##*/}" | awk -F'.conf:' '{print $1}' )"
 				MATCH_NAME="$( echo "${i##*/}" | awk -F'NAME="' '{print $2}' )"
-				MATCH_NAME="$( echo ${MATCH_NAME::-1} | xargs )"
+				MATCH_NAME="$( echo "${MATCH_NAME::-1}" | xargs )"
 
-				printf "$MATCH_AID\t\t($MATCH_NAME)\n"
+				printf '%s\t\t(%s)\n' "$MATCH_AID" "$MATCH_NAME"
 			done
 		else
 			echo "Could not find AppID for name '$1'."


### PR DESCRIPTION
Fixes all warnings/style messages of `shellcheck steamtinkerlaunch`. The biggest change is that `mapfile` is used to generate the array (removes the need for the `IFS` stuff). `[*]` is also used in the if blocks to expand the `MATCHES` array.

I also noticed a small issue which I fixed in this PR: I forgot to use `grep -i` when checking on `GAMENAME`, which meant checks on that var weren't case-insensitive. That has been fixed.

I did some pretty extensive testing to try and make *absolutely* sure that I didn't inadvertently break anything while trying to fix these warnings. Everything seems to work just as it did before.

I'll be sure to run `shellcheck` in future before submitting PRs.