### PR TITLE
Allow tray icon in Steam Deck Desktop Mode

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -4529,8 +4529,8 @@ function openTrayIcon {
 		loadCfg "$STLGAMECFG"
 	fi
 
-	if [ "$ONSTEAMDECK" -eq 1 ]; then
-		writelog "SKIP" "${FUNCNAME[0]} - Skipping TrayIcon on SteamDeck" "X"
+	if [ "$ONSTEAMDECK" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
+		writelog "SKIP" "${FUNCNAME[0]} - Skipping TrayIcon on SteamDeck Game Mode" "X"
 	else
 		if [ -z "$YADTRAYPID" ] && [ "$USETRAYICON" -eq 1 ]; then
 			writelog "INFO" "${FUNCNAME[0]} - Opening trayIcon:" "X"


### PR DESCRIPTION
The Steam Deck should be able to use the tray icon in Desktop Mode, so only disable it on Steam Deck Game Mode.

It might not be very likely that a user would use STL in Desktop Mode and need the tray icon but since we have this variable now imo it makes sense to start enabling some STL functionality like this when we're in Desktop Mode. I have a few other branches where I'm experimenting with similar ideas, I'll open some PRs after more testing :smile: 