### PR TITLE
Allow GameScope on Steam Deck Desktop Mode

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -20079,8 +20079,8 @@ function steamdeckClose {
 
 function steamdeckBeforeGame {
 	if [ "$ONSTEAMDECK" -eq 1 ]; then
-		if [ "$USEGAMESCOPE" -eq 1 ]; then
-			writelog "SKIP" "${FUNCNAME[0]} - Disabling own gamescope on SteamDeck" "X"
+		if [ "$USEGAMESCOPE" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
+			writelog "SKIP" "${FUNCNAME[0]} - Disabling own gamescope on SteamDeck Game Mode" "X"
 			USEGAMESCOPE=0
 		fi
 


### PR DESCRIPTION
GameScope can be used on Steam Deck in Desktop Mode, so only disable it if we're running on Steam Deck Game Mode where it could potentially conflict.

Even if a user has enabled it in Desktop Mode, because of the exist `USEGAMESCOPE=0` part in the detection for running in Game Mode, GameScope should be disabled when running in Game Mode automatically.

I don't think it's very likely a user would play games in Desktop Mode, but I can envision a case where they might have their Deck hooked up with a keyboard and mouse to a monitor and they want to play some light games with GameScope features. I think it makes sense to allow GameScope in Desktop Mode for these kinds of use-cases.

Thanks! :smile: 