### PR TITLE
Allow GameMode on Steam Deck Desktop Mode

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -20084,8 +20084,8 @@ function steamdeckBeforeGame {
 			USEGAMESCOPE=0
 		fi
 
-		if [ "$USEGAMEMODERUN" -eq 1 ]; then
-			writelog "SKIP" "${FUNCNAME[0]} - Disabling own gamemode on SteamDeck" "X"
+		if [ "$USEGAMEMODERUN" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
+			writelog "SKIP" "${FUNCNAME[0]} - Disabling own gamemode on SteamDeck Game Mode" "X"
 			USEGAMEMODERUN=0
 		fi
 		


### PR DESCRIPTION
To my (pleasant!) surprise, Steam Deck comes with Game Mode :open_mouth: Pretty nifty!

This PR lets users enable GameMode on their Steam Deck in Desktop Mode. Since it's pre-installed on Deck I would imagine Valve use it in Game Mode though I didn't verify this. But to prevent any potential conflicts now and in future, this option is only allowed in Desktop Mode.

I confirmed that it worked by running Terraria with Game Mode enabled and running `gamemoded -s`, which tells you if GameMode is running or not. I thought about doing a check on the result of `gamemoded -s` or checking if `gamemoded` was running in some other way (instead of checking on `$FIXGAMESCOPE`) but decided against it because we pretty much only want to catch this if the user is playing on Deck in Game Mode, on Desktop Mode they can do whatever they like as they can on a regular Linux Desktop :-) If  they enabled Game Mode in Desktop Mode it's not worth us checking for it I don't think. Disabling it is just a precautionary measure in Game Mode

Also, this and the other PRs were all separate because I tested these individually on my Deck to make absolutely sure they worked. Sorry for the PR spam though since it's essentially the same change I realise now probably nothing would've broken, but I try to be thorough. Plus explaining my rationale for each one in separate PRs helps me keep the rationale for my changes all straight in my head.

Thanks! All feedback welcome as usual :heart: 