### PR TITLE
Enable notifier on Steam Deck Desktop Mode

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -3437,8 +3437,8 @@ function saveCfg {
 }
 
 function notiShow {
-	if [ "$ONSTEAMDECK" -eq 1 ]; then
-		writelog "INFO" "${FUNCNAME[0]} - Skipping notifier on SteamDeck"
+	if [ "$ONSTEAMDECK" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ] ; then
+		writelog "INFO" "${FUNCNAME[0]} - Skipping notifier on SteamDeck Game Mode"
 		USENOTIFIER=0 # might avoid a 2nd try during this session
 	else
 		if [ -n "$2" ] && [ "$2" == "X" ]; then


### PR DESCRIPTION
Adds a check for `$FIXGAMESCOPE -eq 1` on Steam Deck before disabling the notifier. Steam Deck can use notify-send in Desktop Mode, so only disable it if we're on Steam Deck and if we're in Game Mode (`$ONSTEAMDECK -eq 1` and `$FIXGAMESCOPE -eq 1`).

This change won't enable the notifier on Steam Deck for new users but it should prevent it from being disabled by default. In my tests, launching a game from Desktop Mode (Terraria) correctly showed the notifier after it was enabled from the Global Menu. Then I launched a game from Game Mode (Persona 4 Golden) and that worked fine, no glitches. Then I went back to Desktop Mode and ran Terraria again and it showed the notifier still. So the `USENOTIFIER=0` should only be a "runtime" change and won't be written out.

Having it enabled for Deck users would be nice but enabling it for existing Deck users while also trying to work out if they might have manually disabled it is probably not really possible, or probably not worth the effort. New users will have the notiifer enabled and users that miss it on Desktop Mode can [read the docs](https://github.com/frostworx/steamtinkerlaunch/wiki/Notifier) and enable it manually in the Global Menu.

This is a change I especially wanted to change and split up even though it is similar to my previous PRs. I wasn't sure if the change would be this straightforward and I wanted to test, plus get feedback on these individual PRs for enabling functionality in Desktop Mode, in case any of them were undesirable for any reason. After my tests I'm confident this is a safe change but as usual all feedback is welcome :smile: 

Thanks!