### PR TITLE
Remove unneeded deps files on Steam Deck

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v11.12.20220924"
+PROGVERS="v11.12.20221005"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -20235,6 +20235,8 @@ function steamdedeckt {
 			setYadBin "ai" "sd"
 		fi
 		
+		find "$STLDEPS" -type f \( -name "*.zst" -o -name "*.gz" -o -name ".*" \) -exec rm {} \;
+
 		# update/set compatibility tool to git stl:
 		if [ "$INFLATPAK" -eq 0 ]; then
 			CompatTool "add" "$PREFIX/$PROGCMD"


### PR DESCRIPTION
Removes the cabextract and innoextract archives, and the dot files extracted with their archives. These files are tiny, totalling just over 250kb, but it helps keep the deps folder clean :slightly_smiling_face: 

I opted to remove innoextract and cabextract by name instead of doing an `rm "*.zst"` because the archives might not always end with a file extension. I did think about maybe removing anything that isn't a folder from the STL deps folder but I thought it was best to have the removal of the archives be very explicit, even if it means duplicating their `rm`. That way if we ever did, for any reason, need to keep the archives around, we can do so.

The dotfiles I grouped all under a single `rm` because there's very likely no reason for a dotfile to ever be used in this folder. The ones that exist there are from whichever dependency was last extracted, so its `.MTREE` and things like that. If it's preferred though I can make these explicit too :smiley: 

As usual, all feedback is appreciated!