### PR TITLE
Fix ReShade Installing Incorrectly into Custom Command

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v11.12.20221219-1"
+PROGVERS="v11.12.20221221-1 (reshade-custcmd-fix)"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -7800,11 +7800,25 @@ function ShaderRepoDialog {
 }
 
 function setFullGameExePath {
-	if [[ ( "$USECUSTOMCMD" -eq 1 && -f "$CUSTOMCMD" ) ]] || [[ ( "$USECUSTOMCMD" -eq 1 && -f "$CUSTOMCMD" && "$CUSTOMCMDRESHADE" -eq 1 ) || "$ONLY_CUSTOMCMD" -eq 1 ]]; then
+	# if [[ ( "$USECUSTOMCMD" -eq 1 && -f "$CUSTOMCMD" ) ]] || [[ ( "$USECUSTOMCMD" -eq 1 && -f "$CUSTOMCMD" && "$CUSTOMCMDRESHADE" -eq 1 ) || "$ONLY_CUSTOMCMD" -eq 1 ]]; then
+	if [[ ( "$USECUSTOMCMD" -eq 1 && -f "$CUSTOMCMD" && "$CUSTOMCMDRESHADE" -eq 1 ) || "$ONLY_CUSTOMCMD" -eq 1 ]]; then
 		FGEP="${CUSTOMCMD%/*}"
+
 		writelog "INFO" "${FUNCNAME[0]} - Using the directory '$FGEP' of the used custom command as absolute game exe path"
+
+		if [ "$CUSTOMCMDRESHADE" -eq 1 ]; then
+			writelog "INFO" "${FUNCNAME[0]} - User enabled 'CUSTOMCMDRESHADE' - Using custom command directory with exe as ReShade installation directory"
+		fi
+
 		export "$1"="$FGEP"
 	else
+		if [ "$USECUSTOMCMD" -eq 1 ] && [ ! -f "$CUSTOMCMD" ]; then
+			writelog "WARN" "${FUNCNAME[0]} - User enabled Custom Command, but custom command at '$CUSTOMCMD' is not a file!"
+		fi
+
+		if [ "$CUSTOMCMDRESHADE" -eq 0 ]; then
+			writelog "INFO" "${FUNCNAME[0]} - User did not enable 'CUSTOMCMDRESHADE' - Using the game's exe directroy as the ReShade installation directory"
+		fi
 		setShaderDest
 		if [ -n "$SHADDESTDIR" ]; then
 			writelog "INFO" "${FUNCNAME[0]} - Using SHADDESTDIR '$SHADDESTDIR' for '$1'"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v11.12.20221221-1 (reshade-custcmd-fix)"
+PROGVERS="v11.12.20221222-1"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -5556,14 +5556,7 @@ function setShadDestDir {
 	fi
 		# setFullGameExePath "SHADDESTDIR"
 #	fi
-
-	# Don't use ReShade for custom command by default - Only use it if the user has enabled it for a valid custom command OR if they've enabled "Only custom command"
-	# if [[ ( "$USECUSTOMCMD" -eq 1 && -f "$CUSTOMCMD" && "$CUSTOMCMDRESHADE" -eq 1 ) || "$ONLY_CUSTOMCMD" -eq 1 ]]; then 
-		# if [ "$USERESHADE" -eq 1 ]; then # Make extra sure we want to use ReShade
-			# writelog "INFO" "${FUNCNAME[0]} - Using ReShade for custom command"
-			setFullGameExePath "SHADDESTDIR"
-		# fi
-	# fi
+	setFullGameExePath "SHADDESTDIR"
 }
 
 function refreshProtList {
@@ -7800,7 +7793,6 @@ function ShaderRepoDialog {
 }
 
 function setFullGameExePath {
-	# if [[ ( "$USECUSTOMCMD" -eq 1 && -f "$CUSTOMCMD" ) ]] || [[ ( "$USECUSTOMCMD" -eq 1 && -f "$CUSTOMCMD" && "$CUSTOMCMDRESHADE" -eq 1 ) || "$ONLY_CUSTOMCMD" -eq 1 ]]; then
 	if [[ ( "$USECUSTOMCMD" -eq 1 && -f "$CUSTOMCMD" && "$CUSTOMCMDRESHADE" -eq 1 ) || "$ONLY_CUSTOMCMD" -eq 1 ]]; then
 		FGEP="${CUSTOMCMD%/*}"
 


### PR DESCRIPTION
Now ReShade will only install to the custom command's executable directory if a specific option is enabled, or if "Only custom command" is enabled.

Resolves #669.