### PR TITLE
Add command line option to run Winecfg for MO2 and Vortex

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v12.12.20230118-3"
+PROGVERS="v12.12.20230119-1 (winecfg-custom-prefix)"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -14889,6 +14889,21 @@ function askVortex {
 	fi
 }
 
+# vtxWinecfg and mo2Winecfg are separate functions and separate from oneTimeWinetricks in case they may need some custom logics
+function vtxWinecfg {
+	setVortexVars
+	getWinecfgExecutable
+
+	if [ -d "$VORTEXPFX" ]; then
+		writelog "INFO" "${FUNCNAME[0]} - Running Winecfg for Vortex"
+		writelog "INFO" "${FUNCNAME[0]} - WINEDEBUG=\"-all\" WINEPREFIX=\"$VORTEXPFX\" \"$VORTEXWINE\" \"$OTWINECFGEXE\""
+		WINEDEBUG="-all" WINEPREFIX="$VORTEXPFX" "$VORTEXWINE" "$OTWINECFGEXE"
+	else
+		writelog "ERROR" "${FUNCNAME[0]} - Vortex is not installed, cannot run Winecfg for Vortex"
+		echo "Vortex is not installed, cannot run Winecfg for Vortex"
+	fi
+}
+
 #### VORTEX STOP ####
 
 #### MO2 MOD ORGANIZER START: ####
@@ -15503,6 +15518,20 @@ function checkMO2 {
 			writelog "INFO" "${FUNCNAME[0]} - Disabling custom command, because $MO2 is enabled"
 			USECUSTOMCMD=0
 		fi
+	fi
+}
+
+function mo2Winecfg {
+	setMO2Vars
+	getWinecfgExecutable
+
+	if [ -d "$MO2PFX" ]; then
+		writelog "INFO" "${FUNCNAME[0]} - Running Winecfg for MO2"
+		writelog "INFO" "${FUNCNAME[0]} - WINEDEBUG=\"-all\" WINEPREFIX=\"$VORTEXPFX\" \"$MO2WINE\" \"$OTWINECFGEXE\""
+		WINEDEBUG="-all" WINEPREFIX="$MO2PFX" "$MO2WINE" "$OTWINECFGEXE"
+	else
+		writelog "ERROR" "${FUNCNAME[0]} - ModOrganizer 2 is not installed, cannot run Winecfg for MO2"
+		echo "ModOrganizer 2 is not installed, cannot run Winecfg for ModOrganizer 2"
 	fi
 }
 
@@ -20153,6 +20182,8 @@ function commandline {
 				StatusWindow "$(strFix "$NOTY_DLCUSTOMPROTON" "${VTX^}")" "dlLatestVortex S" "DownloadVortexStatus"
 			elif [ "$2" == "activate" ] && { [ -n "$3" ]  && [ "$3" -eq "$3" ] 2>/dev/null;}; then
 				startVortex "activate" "$3"
+			elif [ "$2" == "winecfg" ]; then
+				vtxWinecfg
 			else	
 				writelog "INFO" "${FUNCNAME[0]} - arg2 '$2' is no valid command"
 				howto

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v12.12.20230119-1 (winecfg-custom-prefix)"
+PROGVERS="v12.12.20230119-1"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -19600,6 +19600,7 @@ function howto {
 	echo "         list-installed|li           list installed games supported by MO2"
 	echo "         create-instance|ci <id>     create MO2 instance for <id>"
 	echo "         url|u <url>                 open nxm url with MO2"
+	echo "         winecfg                     Run Winecfg with MO2 Wine in MO2 prefix"
 	echo "    play <gameid>                    Start game with id <gameid> directly" 
  	echo "    proton|p <title> <X>             Start and/or create <title> with proton"
 	echo "                                       without using steam."
@@ -19655,6 +19656,7 @@ function howto {
 	echo "           getset                      Show config of installed ${VTX^}"
 	echo "           reset                       Reset all autodetected settings in ${VTX^}"
 	echo "           stage <path>                Add ${VTX^} stage via dialog"
+	echo "           winecfg                     Run Winecfg with ${VTX^} Wine in ${VTX^} prefix"
     echo "                                       or directly the one given in <path>"
 	echo "    vr <windowname> <SteamAppID> <s> Start SBS-VR mode for <windowname>"
 	echo "                                       and game <SteamAppID>"
@@ -19880,6 +19882,8 @@ function commandline {
 				fi
 			elif [ "$2" == "url" ] || [ "$2" == "u" ]; then
 				dlMod2nexurl "$3"
+			elif [ "$2" == "winecfg" ]; then
+				mo2Winecfg
 			else
 				writelog "INFO" "${FUNCNAME[0]} - arg2 '$2' is no valid command"
 				howto


### PR DESCRIPTION
Adds `steamtinkerlaunch mo2 winecfg` and `steamtinkerlaunch vortex winecfg` commands.

May be useful for instances like #682, and also helps resolve a comment left in https://github.com/sonic2kk/steamtinkerlaunch/issues/692#issuecomment-1356509825.