### PR TITLE
Add some redundancy for no internet connection check

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -22860,7 +22860,7 @@ function steamdedeckt {
 			notiShow "$NOTY_STEAMDECK_INSTALL" "X"
 			echo "$NOTY_STEAMDECK_INSTALL on Steam Deck"
 
-			if ! ping -q -c1 archlinux.org &>/dev/null; then
+			if ! ((ping -q -c1 archlinux.org &>/dev/null) || (ping -q -c1 google.com &>/dev/null)); then
 				INTERNETCONNECTION=0
 				writelog "WARN" "${FUNCNAME[0]} - No Internet Connection detected, attempting to install SteamTinkerLaunch offline - This may not succeed!"
 				writelog "WARN" "${FUNCNAME[0]} - Make sure you have either manually installed all dependencies, or added all manual dependency archives to '$STLDEPS'"


### PR DESCRIPTION
Was going through the install process for someone and they kept getting this No internet connection error message. Maybe the archlinux.org site was blocking ping? Nice to have some redundancy with another domain here since it's not actually dependent on that website. I tested and the fix works.  Here's the error we saw (multiple tries same result):

```
  inflating: /home/deck/horizon-xi/stl/sonic2kk-steamtinkerlaunch-e7c5ada/misc/vortexgames.txt  
  inflating: /home/deck/horizon-xi/stl/sonic2kk-steamtinkerlaunch-e7c5ada/misc/winedebugchannels.txt  
  inflating: /home/deck/horizon-xi/stl/sonic2kk-steamtinkerlaunch-e7c5ada/misc/x64dbg.reg  
  inflating: /home/deck/horizon-xi/stl/sonic2kk-steamtinkerlaunch-e7c5ada/steamtinkerlaunch  
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12113  100 12113    0     0  52463      0 --:--:-- --:--:-- --:--:-- 52665
Preparing to install SteamTinkerLaunch on Steam Deck
WARNING: No Internet Connection - SteamTinkerLaunch will attempt to install offline
No existing STL installation found, so copying installation files to '/home/deck/stl/prefix' for offline installation...

Dependency 'wget' already installed, nothing to do.
Installing dependency 'innoextract'
WARNING: No Internet Connection, cannot download dependency 'innoextract-1.9-7-x86_64.pkg.tar.zst'. For offline installation, manually place the file in '/home/deck/stl/deps'.
Could not find any archive in '/home/deck/stl/deps' for 'innoextract-1.9-7-x86_64.pkg.tar.zst', aborting install...

Failed to install SteamTinkerLaunch, check command line or log file at '/dev/shm/steamtinkerlaunch/steamtinkerlaunch.log' for errors
```