### PR TITLE
Vortex: Gate Pre-Release Installation Behind Checkbox

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230509-2"
+PROGVERS="v14.0.20230514-1 (vtx-stable-pre-logic)"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -5302,7 +5302,7 @@ function AllSettingsEntriesDummyFunction {
 --field="     $GUI_WAITVORTEX!$DESC_WAITVORTEX ('WAITVORTEX')":NUM "${WAITVORTEX/#-/ -}" `#CAT_Vortex` `#MENU_GAME` \
 --field="     $GUI_RUN_VORTEX_WINETRICKS!$DESC_RUN_VORTEX_WINETRICKS ('RUN_VORTEX_WINETRICKS')":CHK "${RUN_VORTEX_WINETRICKS/#-/ -}" `#CAT_Vortex` `#MENU_GAME` \
 --field="     $GUI_RUN_VORTEX_WINECFG!$DESC_RUN_VORTEX_WINECFG ('RUN_VORTEX_WINECFG')":CHK "${RUN_VORTEX_WINECFG/#-/ -}" `#CAT_Vortex` `#MENU_GAME` \
---field="     $GUI_USEVORTEXPRERELEASE!$DESCUSEVORTEXPRERELEASE ('USEVORTEXPRERELEASE')":CHK "${USEVORTEXPRERELEASE/#-/ -}" `#CAT_Vortex` `#SUB_Checkbox` `#MENU_GLOBAL`  \
+--field="     $GUI_USEVORTEXPRERELEASE!$DESC_USEVORTEXPRERELEASE ('USEVORTEXPRERELEASE')":CHK "${USEVORTEXPRERELEASE/#-/ -}" `#CAT_Vortex` `#SUB_Checkbox` `#MENU_GLOBAL`  \
 --field="     $GUI_VORTEXDOWNLOADPATH!$DESC_VORTEXDOWNLOADPATH ('VORTEXDOWNLOADPATH')":DIR "${VORTEXDOWNLOADPATH/#-/ -}" `#CAT_Vortex` `#SUB_Directories` `#MENU_GLOBAL` \
 --field="     $GUI_VORTEXCOMPDATA!$DESC_VORTEXCOMPDATA ('VORTEXCOMPDATA')":DIR "${VORTEXCOMPDATA/#-/ -}" `#CAT_Vortex` `#SUB_Directories` `#MENU_GLOBAL` \
 --field="     $GUI_USEVORTEXPROTON!$DESC_USEVORTEXPROTON ('USEVORTEXPROTON')":CB "$(cleanDropDown "${USEVORTEXPROTON/#-/ -}" "$PROTYADLIST")" `#CAT_Vortex` `#MENU_GLOBAL` \
@@ -13919,10 +13919,15 @@ function createHMMDesktopFile {
 function getLatestGitHubExeVer {
     SETUPNAME="$1"
     PROJURL="$2"
+    EXCLUDEPRERELEASES="${3:-0}"  # i.e. to only get latest stable Vortex
 
     RELEASESURL="${PROJURL}/releases"
     EXPANDEDASSETSURL="${RELEASESURL}/expanded_assets"
-    TAGSURL="${PROJURL}/tags"
+    if [ "$EXCLUDEPRERELEASES" -eq 1 ]; then
+        TAGSURL="${RELEASESURL}/latest"  # Will redirect to release tagged with "latest" instead of pre-release
+    else
+        TAGSURL="${PROJURL}/tags"
+    fi
 
     TAGSGREP="${RELEASESURL#"$GHURL"}/tag"
 
@@ -14037,10 +14042,16 @@ function setVortexDLMime {
 	fi
 }
 
+# Get beta Vortex (rename function to "getBetaVortVer"?)
 function getLatestVortVer {
 	VSET="$VTX-setup"
-	writelog "INFO" "${FUNCNAME[0]} - Search for latest ${VTX^} stable Release"
-	VORTEXSETUP="$(getLatestGitHubExeVer "$VSET" "$VORTEXPROJURL")"
+	if [ "$USEVORTEXPRERELEASE" -eq 1 ]; then
+		writelog "INFO" "${FUNCNAME[0]} - Search for latest ${VTX^} Beta Release, if one is available (will fall back to Stable by default)"
+		VORTEXSETUP="$(getLatestGitHubExeVer "$VSET" "$VORTEXPROJURL" )"
+	else
+		writelog "INFO" "${FUNCNAME[0]} - Search for latest ${VTX^} Stable Release"
+		VORTEXSETUP="$(getLatestGitHubExeVer "$VSET" "$VORTEXPROJURL" "1" )"
+	fi
 	writelog "INFO" "${FUNCNAME[0]} - Found '$VORTEXSETUP'"
 	echo "VORTEXSETUP=$VORTEXSETUP" > "$VTST"
 }

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230514-1 (vtx-stable-pre-logic)"
+PROGVERS="v14.0.20230515-1"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"


### PR DESCRIPTION
## Overview
Currently SteamTinkerLaunch always defaults to downloading the latest Vortex release, even if that is a pre-release. This may not be desirable for any number of reasons, including stability, and that I believe it defaults users to the "Beta" release channel (which is not a good idea under Wine).

There was a checkbox existing already on the Global Menu to use Vortex pre-releases, but this checkbox does nothing. In fact, the tooltip was not even properly displayed as the variable used to set the description was incorrect (missing an underscore in `DESC_USEVORTEXPRERELEASE`).

This PR adds functionality to this checkbox. We check if this checkbox is enabled and if it is, we pass a new optional parameter to `getLatestGitHubExeVer`. This parameter controls the URL that we send to `wget` in order to `grep` for the latest tag.

## Implementation
When we're fetching the latest regardless of whether it's stable or pre-release, we grep the `https://github.com/orguser/project/releases/tags` URL and get the first link on this page which matches a set tags regex, which in the case of MO2, Vortex, and HMM, points to the latest release.

This PR changes the logic so that if we want the latest stable, we `wget` the url `https://github.com/orguser/project/releases/latest`, which will always point to the ***latest stable tagged release***. For Vortex, currently `1.8.1` is the latest stable and `1.8.2` is the latest pre-release. The `releases/latest` page will point to `1.8.1`, but the `releases/tags` URL will have a list of *all* release tags in descending order, *including* pre-release tags. The regex we use to get the first matching URL that has a release version works for the `releases/tags` and `releases/latest` page, so we only need to change the value of `TAGSURL` based on whether `EXCLUDEPRERELEASES` (the checkbox value) is true (`1`) or not. The rest of `getLatestGitHubExeVer` should remain unchanged. And since this is an optional parameter, there should be no breaking changes to this function as a result of this PR.

This will not retroactively impact Vortex installations, it will only apply to fresh installations.

## Adjacent Work
This PR is the beginning of some work to try and improve stability under Vortex, given the recent breakage under Wine requiring newer GE installations. There are two pieces of future work that will add to the usefulness of this PR:
- Investigate removing .NET installation logic, as Vortex 1.8 should be able to install .NET itself now(?)
- Add option to disable Vortex auto updates by setting `setVortSet "settings.update.channel=\"\\\"$NEXUPDATECHANNEL\\\"\""`, which should allow users to stay on the current stable release that they install. If this option is disabled, Vortex should default to pre-release if the checkbox option from this PR is enabled, and otherwise revert to stable.

<hr>

TODO:
- [x] Test actual Vortex installation, only tested downloading the exe for now with `steamtinkerlaunch vortex download`