### PR TITLE
Vortex: Remove dotnet48 installation; use Winetricks for dotnetdesktop6

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230516-2 (vtx-dotnet-freedom)"
+PROGVERS="v14.0.20230516-2"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230516-1 (vtx-dotnet-freedom)"
+PROGVERS="v14.0.20230516-2 (vtx-dotnet-freedom)"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -14730,38 +14730,6 @@ function startVortex {
 			WINE="$VORTEXWINE" WINEDEBUG="-all" WINEPREFIX="$VORTEXPFX" "$WINECFG"
 		fi
 
-		## 1.8.0+ only requires DotNet6, however Winetricks should be able to install DotNet6 now, so refactor this to install DotNet6
-
-		# if [ ! -d "$VORTEXDOTNETDIR" ] || [ ! -f "$VORTEXDOTNETDIR/dotnet.exe" ]; then
-		# 	writelog "INFO" "${FUNCNAME[0]} - DotNet6 is not installed yet"
-		# 	DNSRC="windowsdesktop-runtime-6.0.6-win-x64.exe"
-		# 	DLSITE="${VORTEXDOWNLOADPATH}/site"
-		# 	if [ ! -f "$DLSITE/$DNSRC" ]; then
-		# 		if [ -f "${VORTEXINSTDIR}/${VTXRAA}" ]; then
-		# 			RAWDNDL="$(grep -am1 "$DNSRC" "${VORTEXINSTDIR}/${VTXRAA}" | grep -oP '="\K[^"},]+')"
-		# 			echo "RAWDNDL '$RAWDNDL'"
-		# 			if grep -q "^https" <<< "$RAWDNDL"	&& grep -q "exe$" <<< "$RAWDNDL"; then
-		# 				writelog "INFO" "${FUNCNAME[0]} - Using download URL found in $VTX '${VTXRAA}'"
-		# 				DNDL="$RAWDNDL"
-		# 				dlCheck "$DNDL" "$DLSITE/$DNSRC" "X" " Downloading installer '$DNSRC' for DotNet6"
-		# 			fi		
-		# 		fi
-				
-		# 		if [ ! -f "$DLSITE/$DNSRC" ]; then
-		# 			writelog "INFO" "${FUNCNAME[0]} - Using hardcoded download URL for DotNet6"
-		# 			DNDL="https://download.visualstudio.microsoft.com/download/pr/9d6b6b34-44b5-4cf4-b924-79a00deb9795/2f17c30bdf42b6a8950a8552438cf8c1/$DNSRC"
-		# 		fi
-		# 		mkdir -p "$DLSITE"
-		# 		dlCheck "$DNDL" "$DLSITE/$DNSRC" "X" " Downloading installer '$DNSRC' for DotNet6"
-		# 	fi
-		# 	if [ -f "$DLSITE/$DNSRC" ]; then
-		# 		writelog "INFO" "${FUNCNAME[0]} - Starting installation of DotNet6 using '$DLSITE/$DNSRC'"
-		# 		cd "$DLSITE" >/dev/null || return
-		# 		wineVortexRun "$VORTEXWINE" "$DNSRC" "/quiet"
-		# 		cd - >/dev/null || return
-		# 	fi			
-		# fi
-
 		if [ -f "$VORTEXEXE" ]; then
 			setVortexDLMime
 			setVortexDLPath
@@ -15081,7 +15049,11 @@ function installVortex {
 				writelog "SKIP" "${FUNCNAME[0]} - VORTEXPROTON '$VORTEXPROTON' not found - can't continue" "E"
 			else
 				writelog "INFO" "${FUNCNAME[0]} - Using '$VORTEXPROTON' for installation" "E"
-				mkProjDir "$VORTEXCOMPDATA"				
+				mkProjDir "$VORTEXCOMPDATA"
+				# Vortex 1.8.0+ only requires DotNet6 (only need to pass desktop6, as installDotNet will append dotnet)
+				writelog "INFO" "${FUNCNAME[0]} - Installing .NET 6 for Vortex Mod Manager"
+				notiShow "$(strFix "$NOTY_INSTSTART" "${DOTN^}")" "S"
+				installDotNet "$VORTEXPFX" "$VORTEXWINE" "desktop6"  # Should be easy to bump if a newer version is ever required
 				touch "${VORTEXCOMPDATA}/tracked_files"
 				STEAM_COMPAT_CLIENT_INSTALL_PATH="$SROOT" STEAM_COMPAT_DATA_PATH="$VORTEXCOMPDATA" "$VORTEXPROTON" "run" 2> "$STLSHM/${FUNCNAME[0]}_protonrun.log"
 				notiShow "$GUI_DONE" "S"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230515-1"
+PROGVERS="v14.0.20230516-1 (vtx-dotnet-freedom)"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -14730,35 +14730,37 @@ function startVortex {
 			WINE="$VORTEXWINE" WINEDEBUG="-all" WINEPREFIX="$VORTEXPFX" "$WINECFG"
 		fi
 
-		if [ ! -d "$VORTEXDOTNETDIR" ] || [ ! -f "$VORTEXDOTNETDIR/dotnet.exe" ]; then
-			writelog "INFO" "${FUNCNAME[0]} - DotNet6 is not installed yet"
-			DNSRC="windowsdesktop-runtime-6.0.6-win-x64.exe"
-			DLSITE="${VORTEXDOWNLOADPATH}/site"
-			if [ ! -f "$DLSITE/$DNSRC" ]; then
-				if [ -f "${VORTEXINSTDIR}/${VTXRAA}" ]; then
-					RAWDNDL="$(grep -am1 "$DNSRC" "${VORTEXINSTDIR}/${VTXRAA}" | grep -oP '="\K[^"},]+')"
-					echo "RAWDNDL '$RAWDNDL'"
-					if grep -q "^https" <<< "$RAWDNDL"	&& grep -q "exe$" <<< "$RAWDNDL"; then
-						writelog "INFO" "${FUNCNAME[0]} - Using download URL found in $VTX '${VTXRAA}'"
-						DNDL="$RAWDNDL"
-						dlCheck "$DNDL" "$DLSITE/$DNSRC" "X" " Downloading installer '$DNSRC' for DotNet6"
-					fi		
-				fi
+		## 1.8.0+ only requires DotNet6, however Winetricks should be able to install DotNet6 now, so refactor this to install DotNet6
+
+		# if [ ! -d "$VORTEXDOTNETDIR" ] || [ ! -f "$VORTEXDOTNETDIR/dotnet.exe" ]; then
+		# 	writelog "INFO" "${FUNCNAME[0]} - DotNet6 is not installed yet"
+		# 	DNSRC="windowsdesktop-runtime-6.0.6-win-x64.exe"
+		# 	DLSITE="${VORTEXDOWNLOADPATH}/site"
+		# 	if [ ! -f "$DLSITE/$DNSRC" ]; then
+		# 		if [ -f "${VORTEXINSTDIR}/${VTXRAA}" ]; then
+		# 			RAWDNDL="$(grep -am1 "$DNSRC" "${VORTEXINSTDIR}/${VTXRAA}" | grep -oP '="\K[^"},]+')"
+		# 			echo "RAWDNDL '$RAWDNDL'"
+		# 			if grep -q "^https" <<< "$RAWDNDL"	&& grep -q "exe$" <<< "$RAWDNDL"; then
+		# 				writelog "INFO" "${FUNCNAME[0]} - Using download URL found in $VTX '${VTXRAA}'"
+		# 				DNDL="$RAWDNDL"
+		# 				dlCheck "$DNDL" "$DLSITE/$DNSRC" "X" " Downloading installer '$DNSRC' for DotNet6"
+		# 			fi		
+		# 		fi
 				
-				if [ ! -f "$DLSITE/$DNSRC" ]; then
-					writelog "INFO" "${FUNCNAME[0]} - Using hardcoded download URL for DotNet6"
-					DNDL="https://download.visualstudio.microsoft.com/download/pr/9d6b6b34-44b5-4cf4-b924-79a00deb9795/2f17c30bdf42b6a8950a8552438cf8c1/$DNSRC"
-				fi
-				mkdir -p "$DLSITE"
-				dlCheck "$DNDL" "$DLSITE/$DNSRC" "X" " Downloading installer '$DNSRC' for DotNet6"
-			fi
-			if [ -f "$DLSITE/$DNSRC" ]; then
-				writelog "INFO" "${FUNCNAME[0]} - Starting installation of DotNet6 using '$DLSITE/$DNSRC'"
-				cd "$DLSITE" >/dev/null || return
-				wineVortexRun "$VORTEXWINE" "$DNSRC" "/quiet"
-				cd - >/dev/null || return
-			fi			
-		fi
+		# 		if [ ! -f "$DLSITE/$DNSRC" ]; then
+		# 			writelog "INFO" "${FUNCNAME[0]} - Using hardcoded download URL for DotNet6"
+		# 			DNDL="https://download.visualstudio.microsoft.com/download/pr/9d6b6b34-44b5-4cf4-b924-79a00deb9795/2f17c30bdf42b6a8950a8552438cf8c1/$DNSRC"
+		# 		fi
+		# 		mkdir -p "$DLSITE"
+		# 		dlCheck "$DNDL" "$DLSITE/$DNSRC" "X" " Downloading installer '$DNSRC' for DotNet6"
+		# 	fi
+		# 	if [ -f "$DLSITE/$DNSRC" ]; then
+		# 		writelog "INFO" "${FUNCNAME[0]} - Starting installation of DotNet6 using '$DLSITE/$DNSRC'"
+		# 		cd "$DLSITE" >/dev/null || return
+		# 		wineVortexRun "$VORTEXWINE" "$DNSRC" "/quiet"
+		# 		cd - >/dev/null || return
+		# 	fi			
+		# fi
 
 		if [ -f "$VORTEXEXE" ]; then
 			setVortexDLMime
@@ -15079,9 +15081,7 @@ function installVortex {
 				writelog "SKIP" "${FUNCNAME[0]} - VORTEXPROTON '$VORTEXPROTON' not found - can't continue" "E"
 			else
 				writelog "INFO" "${FUNCNAME[0]} - Using '$VORTEXPROTON' for installation" "E"
-				mkProjDir "$VORTEXCOMPDATA"
-				notiShow "$(strFix "$NOTY_INSTSTART" "${DOTN^}")" "S"
-				installDotNet "$VORTEXPFX" "$VORTEXWINE" "48"
+				mkProjDir "$VORTEXCOMPDATA"				
 				touch "${VORTEXCOMPDATA}/tracked_files"
 				STEAM_COMPAT_CLIENT_INSTALL_PATH="$SROOT" STEAM_COMPAT_DATA_PATH="$VORTEXCOMPDATA" "$VORTEXPROTON" "run" 2> "$STLSHM/${FUNCNAME[0]}_protonrun.log"
 				notiShow "$GUI_DONE" "S"


### PR DESCRIPTION
Vortex 1.8.0 and above no longer require dotnet48 to install, however Vortex still requires .NET 6 or above. The manual .NET 6 installation works, but Winetricks should be able to install .NET 6 for us, so we should replace the manual code. This was not the case when this logic was written, as Winetricks could not install dotnet6 at that time.

The relevant Winetrick we want is `dotnetdesktop6`. I am not sure if this is available in the latest stable Winetricks, but as all users should know, an up-to-date Winetricks should always be used when tinkering. A note will be added to the Vortex wiki around this.

Currently Vortex will work with this PR, but it'll tell you that you need .NET 6 or above. It does offer a fix, and the fix *will* correctly install .NET 6, but I would still rather automate this step as it should be relatively cheap. Also, the .NET 6 install logic was in the `startVortex` section. I guess this was because it was needed *after* Vortex was installed and set up, but now it can probably go in the `installVortex` section.

This should also significantly reduce the footprint that Vortex has, down from about 3.5gb to 1.2gb on my PC. Installation also seems to be around a minute or so faster (dotnetdesktop6 installs *very* quickly compared to dotnet48).