### PR TITLE
Vortex: Use Steam Linux Runtime for Installation

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230529-2 (vortex-slr-install)"
+PROGVERS="v14.0.20230528-3"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230528-2"
+PROGVERS="v14.0.20230529-1 (vortex-slr-install)"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -15196,8 +15196,18 @@ function installVortex {
 				sleep 3
 				writelog "INFO" "${FUNCNAME[0]} - Installing '$VSPATH' into '$VORTEXPFX'" E
 				notiShow "$(strFix "$NOTY_INSTSTART" "${VSPATH##*/}")" "S"
-				writelog "INFO" "${FUNCNAME[0]} - 'WINEDEBUG=\"-all\" WINEPREFIX=\"$VORTEXPFX\" \"$VORTEXWINE\" \"$VSPATH\" \"/S\"'" E
-				WINEDEBUG="-all" WINEPREFIX="$VORTEXPFX" "$VORTEXWINE" "$VSPATH" "/S"
+				# writelog "INFO" "${FUNCNAME[0]} - 'WINEDEBUG=\"-all\" WINEPREFIX=\"$VORTEXPFX\" \"$VORTEXWINE\" \"$VSPATH\" \"/S\"'" E
+				
+				setNonGameSLRReap "1" "$USEVORTEXPROTON"
+				if [ -n "${SLRCMD[*]}" ]; then
+					writelog "INFO" "${FUNCNAME[0]} - 'WINEDEBUG=\"-all\" WINEPREFIX=\"$VORTEXPFX\" \"${SLRCMD[*]}\" \"$VORTEXWINE\" \"$VSPATH\" \"/S\"'" E
+					WINEDEBUG="-all" WINEPREFIX="$VORTEXPFX" "${SLRCMD[@]}" "$VORTEXWINE" "$VSPATH" "/S"
+				else
+					writelog "INFO" "${FUNCNAME[0]} - 'WINEDEBUG=\"-all\" WINEPREFIX=\"$VORTEXPFX\" \"$VORTEXWINE\" \"$VSPATH\" \"/S\"'" E
+					WINEDEBUG="-all" WINEPREFIX="$VORTEXPFX" "$VORTEXWINE" "$VSPATH" "/S"
+				fi
+				unset "${SLRCMD[@]}"
+				
 				notiShow "$(strFix "$NOTY_INSTSTOP" "${VSPATH##*/}")" "S"
 				writelog "INFO" "${FUNCNAME[0]} - Base ${VTX^} installation finished" E
 				setVortexDLMime

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230529-1 (vortex-slr-install)"
+PROGVERS="v14.0.20230529-2 (vortex-slr-install)"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -15198,8 +15198,15 @@ function installVortex {
 				notiShow "$(strFix "$NOTY_INSTSTART" "${VSPATH##*/}")" "S"
 				# writelog "INFO" "${FUNCNAME[0]} - 'WINEDEBUG=\"-all\" WINEPREFIX=\"$VORTEXPFX\" \"$VORTEXWINE\" \"$VSPATH\" \"/S\"'" E
 				
-				setNonGameSLRReap "1" "$USEVORTEXPROTON"
-				if [ -n "${SLRCMD[*]}" ]; then
+				# --------------------------
+				# Get SLR for Vortex Proton 
+				unset "${SLRCMD[@]}"
+				if [ "$VORTEXUSESLR" -eq 1 ]; then
+					setNonGameSLRReap "1" "$USEVORTEXPROTON"
+				fi
+
+				# If we got the runtime above and we want to use the SLR with Vortex, use it to install Vortex
+				if [ "$VORTEXUSESLR" -eq 1 ] && [ -n "${SLRCMD[*]}" ]; then
 					writelog "INFO" "${FUNCNAME[0]} - 'WINEDEBUG=\"-all\" WINEPREFIX=\"$VORTEXPFX\" \"${SLRCMD[*]}\" \"$VORTEXWINE\" \"$VSPATH\" \"/S\"'" E
 					WINEDEBUG="-all" WINEPREFIX="$VORTEXPFX" "${SLRCMD[@]}" "$VORTEXWINE" "$VSPATH" "/S"
 				else
@@ -15207,6 +15214,7 @@ function installVortex {
 					WINEDEBUG="-all" WINEPREFIX="$VORTEXPFX" "$VORTEXWINE" "$VSPATH" "/S"
 				fi
 				unset "${SLRCMD[@]}"
+				# --------------------------
 				
 				notiShow "$(strFix "$NOTY_INSTSTOP" "${VSPATH##*/}")" "S"
 				writelog "INFO" "${FUNCNAME[0]} - Base ${VTX^} installation finished" E


### PR DESCRIPTION
Should fix #806, for real this time.

If the `VORTEXUSESLR` is enabled, we attempt to install Vortex using the Steam Linux Runtime. As usual, if the SLR that a tool requires is not found, we will just run without the SLR.

This change is needed because SteamOS apparently needs the SLR to install Vortex properly at all.

Special thanks to @pikdum for spending a lot of time investigating and troubleshooting these issues.