### PR TITLE
Ensure write permissions before and after lang file update

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -2263,8 +2263,10 @@ function loadLangFile {
 
 				if [ -n "$UPDATELANGFILEPATH" ]; then
 					writelog "INFO" "${FUNCNAME[0]} - Found lang file to replace the existing user-installed file with under '$UPDATELANGFILEPATH'"
+          chmod +w "$LAFI" #Ensure write permissions before removing
 					rm "$LAFI"
 					cp "$UPDATELANGFILEPATH" "$LAFI"
+          chmod -R +w "$STLLANGDIR" #Ensure write permissions for next update!
 				else
 					writelog "INFO" "${FUNCNAME[0]} - No lang file to replace existing user-installed file with, not updating langfile"
 				fi


### PR DESCRIPTION
Related to #822

Use `chmod` to make sure language files in the user's config directory have write permissions before AND after updating them.

I've decided on ensuring write permissions before and after the update just in case of an unforeseen edge case.

## Testing
1. Remove write permissions from all language files in the config's `lang/` directory with `chmod -R -w /path/to/config/lang`
2. In a terminal, execute `steam`
3. Pick a game. In the game's Properties, force the use of `steamtinkerlaunch`
4. Start the game
5. Check that in steam's stdout, there are no complaints of `rm` waiting for user input to proceed with removing existing language file(s)