### PR TITLE
GameScope: Update --hdr-sdr-content-nits default value

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230710-1"
+PROGVERS="v14.0.20230710-1 (gamescope-hdr-updates)"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -9970,7 +9970,7 @@ function setGameScopeVars {
 		# HDR Wide Gammut for SDR (--hdr-wide-gammut-for-sdr) - Checkbox
 		GSHDRWGFS="$( getGameScopeArg "$GAMESCOPE_ARGS" "--hdr-wide-gammut-for-sdr" "$GSHDRWGFS" "1" "0" )"
 
-		# HDR SDR Content Nits (--hdr-sdr-content-nits) -- Defaults to 203 -- Numberbox
+		# HDR SDR Content Nits (--hdr-sdr-content-nits) -- Defaults to 400 -- Numberbox
 		GSHDRSCNITS="$( getGameScopeArg "$GAMESCOPE_ARGS" "--hdr-sdr-content-nits" "$GSHDRSCNITS" "1" "0" )"
 
 		# HDR Inverse Tone Mapping Enabled (--hdr-itm-enable) -- Checkbox
@@ -9989,6 +9989,9 @@ function setGameScopeVars {
 		#
 		# Like `GSHDRITMSDRNITS`, we default to 0 because we don't want to always pass a value
 		GSHDRITMTGTNITS="$( getGameScopeArg "$GAMESCOPE_ARGS" "--hdr-itm-target-nits" "$GSHDRITMTGTNITS" "" "0" "num" )"
+
+		# There is a --sdr-gamut-wideness option which takes a (float?) value between 0 and 1. Not sure how this is used or what the default is,
+		# so it is not added for now, but it could be added in future if requested/once more is known about it
 	}
 
 	function getGameScopeVROpts {
@@ -10378,8 +10381,8 @@ function GameScopeGui {
 								writelog "WARN" "${FUNCNAME[0]} - GSHDRWGFS (--hdr-wide-gammut-for-sdr) option for GameScope enabled but HDR was not enabled - Ignoring as this option would have no effect"
 							fi
 						fi
-						if [ ! "$GSHDRSCNITS" == "203" ]; then
-							# Only pass value if nits != 203 && HDR enabled
+						if [ ! "$GSHDRSCNITS" == "400" ]; then
+							# Only pass value if nits != 400 && HDR enabled (400 is the default)
 							if [ "$GSHDR" == "TRUE" ] && [ "$GSHDRWGFS" == "TRUE" ]; then
 								GAMESCOPE_ARGS="${GAMESCOPE_ARGS} --hdr-sdr-content-nits ${GSHDRSCNITS}"
 							else

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230710-1 (gamescope-hdr-updates)"
+PROGVERS="v14.0.20230710-2"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"


### PR DESCRIPTION
The default value for `--hdr-sdr-content-nits` is now 400 instead of 203. This updates the check for the default value and a couple of comments around it.

This PR also documents the `--sdr-gamut-wideness` option. I initially considered adding that as part of the PR, but I was not sure what the default value is. I briefly documented it in the code, so if in future if we want to add this/if it's requested, it can be added.