### PR TITLE
Update flatpak .desktop generation

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -14155,7 +14155,11 @@ function createHMMDesktopFile {
 		echo "Name=${HMMNICE}"
 		echo "Comment=A mod manager for Hedgehog Engine games on PC (Installed by SteamTinkerLaunch)"
 		echo "MimeType=x-scheme-handler/hedgemm"
-		echo "Exec=$(realpath "$0") ${HMM,,} start ${HMMAUTO} \"%u\""  # "hmm start" takes dl channel as argument, next arg is the URL
+		if [ "$INFLATPAK" -eq 1 ]; then
+			echo "Exec=flatpak run --command=steamtinkerlaunch $FLATPAK_ID ${HMM,,} start ${HMMAUTO} \"%u\""  # "hmm start" takes dl channel as argument, next arg is the URL
+		else
+			echo "Exec=$(realpath "$0") ${HMM,,} start ${HMMAUTO} \"%u\""  # "hmm start" takes dl channel as argument, next arg is the URL
+		fi
 		echo "Icon=${HMMICOPATH}"
 		echo "Terminal=false"
 		echo "X-KeepTerminal=false"
@@ -14187,7 +14191,11 @@ function createHMMDesktopFile {
 		echo "Terminal=false"
 		echo "X-KeepTerminal=false"
 		echo "Path=$HMMDLDIR"
-		echo "Exec=$(realpath "$0") ${HMM,,} u %u"  # "hmm start" takes dl channel as argument, next arg is the URL
+		if [ "$INFLATPAK" -eq 1 ]; then
+			echo "Exec=flatpak run --command=steamtinkerlaunch $FLATPAK_ID ${HMM,,} u %u"  # "hmm start" takes dl channel as argument, next arg is the URL
+		else
+			echo "Exec=$(realpath "$0") ${HMM,,} u %u"  # "hmm start" takes dl channel as argument, next arg is the URL
+		fi
 		echo "NoDisplay=false"
 		echo "Hidden=false"
 	} >> "$HMMDFDLPA"
@@ -14318,7 +14326,11 @@ function setVortexDLMime {
 		echo "Terminal=false"
 		echo "X-KeepTerminal=false"
 		echo "Path=$(dirname "$VORTEXEXE")"
-		echo "Exec=$(realpath "$0") $VTX u %u"
+		if [ "$INFLATPAK" -eq 1 ]; then
+			echo "Exec=flatpak run --command=steamtinkerlaunch $FLATPAK_ID ${HMM,,} $VTX u %u"
+		else
+			echo "Exec=$(realpath "$0") $$VTX u %u"
+		fi
 		echo "NoDisplay=false"
 		echo "Hidden=false"
 		} >> "$FVD"
@@ -16155,7 +16167,11 @@ function setMO2DLMime {
 		echo "Terminal=false"
 		echo "X-KeepTerminal=false"
 		echo "Path=$(dirname "$MO2EXE")"
-		echo "Exec=$(realpath "$0") mo2 u %u"
+		if [ "$INFLATPAK" -eq 1 ]; then
+			echo "Exec=flatpak run --command=steamtinkerlaunch $FLATPAK_ID mo2 u %u"
+		else
+			echo "Exec=$(realpath "$0") mo2 u %u"
+		fi
 		echo "NoDisplay=false"
 		echo "Hidden=false"
 		} >> "$FMO2D"
@@ -19036,7 +19052,11 @@ function standaloneDesktopFile {
 				echo "[Desktop Entry]"
 				echo "Name=${GAMENAME//\"/}"
 				echo "Comment=$(strFix "$DF_SLCOMMENT" "${GAMENAME//\"/}" "$PROGNAME")"
-				echo "Exec=$(realpath "$0") play $AID"
+				if [ "$INFLATPAK" -eq 1 ]; then
+					echo "Exec=flatpak run --command=steamtinkerlaunch $FLATPAK_ID play $AID"
+				else
+					echo "Exec=$(realpath "$0") play $AID"
+				fi
 				echo "Icon=$WANTGPNG"
 				echo "Terminal=false"
 				echo "Type=Application"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -14156,7 +14156,7 @@ function createHMMDesktopFile {
 		echo "Comment=A mod manager for Hedgehog Engine games on PC (Installed by SteamTinkerLaunch)"
 		echo "MimeType=x-scheme-handler/hedgemm"
 		if [ "$INFLATPAK" -eq 1 ]; then
-			echo "Exec=flatpak run --command=steamtinkerlaunch $FLATPAK_ID ${HMM,,} start ${HMMAUTO} \"%u\""  # "hmm start" takes dl channel as argument, next arg is the URL
+			echo "Exec=/usr/bin/flatpak run --command=steamtinkerlaunch $FLATPAK_ID ${HMM,,} start ${HMMAUTO} \"%u\""  # "hmm start" takes dl channel as argument, next arg is the URL
 		else
 			echo "Exec=$(realpath "$0") ${HMM,,} start ${HMMAUTO} \"%u\""  # "hmm start" takes dl channel as argument, next arg is the URL
 		fi
@@ -14192,7 +14192,7 @@ function createHMMDesktopFile {
 		echo "X-KeepTerminal=false"
 		echo "Path=$HMMDLDIR"
 		if [ "$INFLATPAK" -eq 1 ]; then
-			echo "Exec=flatpak run --command=steamtinkerlaunch $FLATPAK_ID ${HMM,,} u %u"  # "hmm start" takes dl channel as argument, next arg is the URL
+			echo "Exec=/usr/bin/flatpak run --command=steamtinkerlaunch $FLATPAK_ID ${HMM,,} u %u"  # "hmm start" takes dl channel as argument, next arg is the URL
 		else
 			echo "Exec=$(realpath "$0") ${HMM,,} u %u"  # "hmm start" takes dl channel as argument, next arg is the URL
 		fi
@@ -14327,7 +14327,7 @@ function setVortexDLMime {
 		echo "X-KeepTerminal=false"
 		echo "Path=$(dirname "$VORTEXEXE")"
 		if [ "$INFLATPAK" -eq 1 ]; then
-			echo "Exec=flatpak run --command=steamtinkerlaunch $FLATPAK_ID ${HMM,,} $VTX u %u"
+			echo "Exec=/usr/bin/flatpak run --command=steamtinkerlaunch $FLATPAK_ID ${HMM,,} $VTX u %u"
 		else
 			echo "Exec=$(realpath "$0") $$VTX u %u"
 		fi
@@ -16168,7 +16168,7 @@ function setMO2DLMime {
 		echo "X-KeepTerminal=false"
 		echo "Path=$(dirname "$MO2EXE")"
 		if [ "$INFLATPAK" -eq 1 ]; then
-			echo "Exec=flatpak run --command=steamtinkerlaunch $FLATPAK_ID mo2 u %u"
+			echo "Exec=/usr/bin/flatpak run --command=steamtinkerlaunch $FLATPAK_ID mo2 u %u"
 		else
 			echo "Exec=$(realpath "$0") mo2 u %u"
 		fi
@@ -19053,7 +19053,7 @@ function standaloneDesktopFile {
 				echo "Name=${GAMENAME//\"/}"
 				echo "Comment=$(strFix "$DF_SLCOMMENT" "${GAMENAME//\"/}" "$PROGNAME")"
 				if [ "$INFLATPAK" -eq 1 ]; then
-					echo "Exec=flatpak run --command=steamtinkerlaunch $FLATPAK_ID play $AID"
+					echo "Exec=/usr/bin/flatpak run --command=steamtinkerlaunch $FLATPAK_ID play $AID"
 				else
 					echo "Exec=$(realpath "$0") play $AID"
 				fi


### PR DESCRIPTION
The flatpak version of steamtinkerlaunch resolves its realpath to be `/app/utils/bin/steamtinkerlaunch`, which is incorrectly set in a .desktop shortcut, i.e., `Exec=/app/utils/steamtinkerlaunch/bin/steamtinkerlaunch hedgemodmanager start auto "%u"`

The shortcut should be directed to `flatpak run --command=steamtinkerlaunch com.valvesoftware.Steam <args>` instead.

The changes are directed to adding an `if` condition that changes the `Exec=` line based on whether `[ $INFLATPAK -eq 1 ]`, such that if stl is running in a flatpak environment, the appropriate flatpak command is used