### PR TITLE
GameScope: Add chckbox for ENABLE_GAMESCOPE_WSI environment variable

### DIFF
--- a/lang/chinese.txt
+++ b/lang/chinese.txt
@@ -1205,3 +1205,5 @@ NOTY_INSTALLSLR_ALREADYEXISTS="Steam Linux Runtime for current Proton version al
 NOTY_INSTALLSLR_NOREQUIRETOOLAPPID="No require_tool_appid specified in tool_manifest for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_NOTOOLMANIFEST="No tool_manifest.vdf found for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_INVALIDGAME="Could not find Proton version for selected game, unable to install Steam Linux Runtime"
+GUI_USEGAMESCOPEWSI="Enable USE_GAMESCOPE_WSI"
+DESC_USEGAMESCOPEWSI="This can be useful for some HDR options and for some DXVK v2.3 vsync optimisations"

--- a/lang/dutch.txt
+++ b/lang/dutch.txt
@@ -1204,3 +1204,5 @@ NOTY_INSTALLSLR_ALREADYEXISTS="Steam Linux Runtime for current Proton version al
 NOTY_INSTALLSLR_NOREQUIRETOOLAPPID="No require_tool_appid specified in tool_manifest for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_NOTOOLMANIFEST="No tool_manifest.vdf found for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_INVALIDGAME="Could not find Proton version for selected game, unable to install Steam Linux Runtime"
+GUI_USEGAMESCOPEWSI="Enable USE_GAMESCOPE_WSI"
+DESC_USEGAMESCOPEWSI="This can be useful for some HDR options and for some DXVK v2.3 vsync optimisations"

--- a/lang/english.txt
+++ b/lang/english.txt
@@ -1205,3 +1205,5 @@ NOTY_INSTALLSLR_ALREADYEXISTS="Steam Linux Runtime for current Proton version al
 NOTY_INSTALLSLR_NOREQUIRETOOLAPPID="No require_tool_appid specified in tool_manifest for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_NOTOOLMANIFEST="No tool_manifest.vdf found for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_INVALIDGAME="Could not find Proton version for selected game, unable to install Steam Linux Runtime"
+GUI_USEGAMESCOPEWSI="Enable USE_GAMESCOPE_WSI environment variable"
+DESC_USEGAMESCOPEWSI="This can be useful for some HDR options and for some DXVK v2.3 vsync optimisations"

--- a/lang/english.txt
+++ b/lang/english.txt
@@ -1205,5 +1205,5 @@ NOTY_INSTALLSLR_ALREADYEXISTS="Steam Linux Runtime for current Proton version al
 NOTY_INSTALLSLR_NOREQUIRETOOLAPPID="No require_tool_appid specified in tool_manifest for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_NOTOOLMANIFEST="No tool_manifest.vdf found for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_INVALIDGAME="Could not find Proton version for selected game, unable to install Steam Linux Runtime"
-GUI_USEGAMESCOPEWSI="Enable USE_GAMESCOPE_WSI environment variable"
+GUI_USEGAMESCOPEWSI="Enable USE_GAMESCOPE_WSI"
 DESC_USEGAMESCOPEWSI="This can be useful for some HDR options and for some DXVK v2.3 vsync optimisations"

--- a/lang/englishUK.txt
+++ b/lang/englishUK.txt
@@ -1204,3 +1204,5 @@ NOTY_INSTALLSLR_ALREADYEXISTS="Steam Linux Runtime for current Proton version al
 NOTY_INSTALLSLR_NOREQUIRETOOLAPPID="No require_tool_appid specified in tool_manifest for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_NOTOOLMANIFEST="No tool_manifest.vdf found for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_INVALIDGAME="Could not find Proton version for selected game, unable to install Steam Linux Runtime"
+GUI_USEGAMESCOPEWSI="Enable USE_GAMESCOPE_WSI"
+DESC_USEGAMESCOPEWSI="This can be useful for some HDR options and for some DXVK v2.3 vsync optimisations"

--- a/lang/french.txt
+++ b/lang/french.txt
@@ -1204,3 +1204,5 @@ NOTY_INSTALLSLR_ALREADYEXISTS="Steam Linux Runtime for current Proton version al
 NOTY_INSTALLSLR_NOREQUIRETOOLAPPID="No require_tool_appid specified in tool_manifest for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_NOTOOLMANIFEST="No tool_manifest.vdf found for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_INVALIDGAME="Could not find Proton version for selected game, unable to install Steam Linux Runtime"
+GUI_USEGAMESCOPEWSI="Enable USE_GAMESCOPE_WSI"
+DESC_USEGAMESCOPEWSI="This can be useful for some HDR options and for some DXVK v2.3 vsync optimisations"

--- a/lang/german.txt
+++ b/lang/german.txt
@@ -1206,3 +1206,5 @@ NOTY_INSTALLSLR_ALREADYEXISTS="Steam Linux Runtime for current Proton version al
 NOTY_INSTALLSLR_NOREQUIRETOOLAPPID="No require_tool_appid specified in tool_manifest for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_NOTOOLMANIFEST="No tool_manifest.vdf found for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_INVALIDGAME="Could not find Proton version for selected game, unable to install Steam Linux Runtime"
+GUI_USEGAMESCOPEWSI="Enable USE_GAMESCOPE_WSI"
+DESC_USEGAMESCOPEWSI="This can be useful for some HDR options and for some DXVK v2.3 vsync optimisations"

--- a/lang/italian.txt
+++ b/lang/italian.txt
@@ -1204,3 +1204,5 @@ NOTY_INSTALLSLR_ALREADYEXISTS="Steam Linux Runtime for current Proton version al
 NOTY_INSTALLSLR_NOREQUIRETOOLAPPID="No require_tool_appid specified in tool_manifest for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_NOTOOLMANIFEST="No tool_manifest.vdf found for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_INVALIDGAME="Could not find Proton version for selected game, unable to install Steam Linux Runtime"
+GUI_USEGAMESCOPEWSI="Enable USE_GAMESCOPE_WSI"
+DESC_USEGAMESCOPEWSI="This can be useful for some HDR options and for some DXVK v2.3 vsync optimisations"

--- a/lang/polish.txt
+++ b/lang/polish.txt
@@ -1204,3 +1204,5 @@ NOTY_INSTALLSLR_ALREADYEXISTS="Steam Linux Runtime for current Proton version al
 NOTY_INSTALLSLR_NOREQUIRETOOLAPPID="No require_tool_appid specified in tool_manifest for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_NOTOOLMANIFEST="No tool_manifest.vdf found for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_INVALIDGAME="Could not find Proton version for selected game, unable to install Steam Linux Runtime"
+GUI_USEGAMESCOPEWSI="Enable USE_GAMESCOPE_WSI"
+DESC_USEGAMESCOPEWSI="This can be useful for some HDR options and for some DXVK v2.3 vsync optimisations"

--- a/lang/russian.txt
+++ b/lang/russian.txt
@@ -1204,3 +1204,5 @@ NOTY_INSTALLSLR_ALREADYEXISTS="Steam Linux Runtime for current Proton version al
 NOTY_INSTALLSLR_NOREQUIRETOOLAPPID="No require_tool_appid specified in tool_manifest for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_NOTOOLMANIFEST="No tool_manifest.vdf found for given Proton version, check logs for more information"
 NOTY_INSTALLSLR_INVALIDGAME="Could not find Proton version for selected game, unable to install Steam Linux Runtime"
+GUI_USEGAMESCOPEWSI="Enable USE_GAMESCOPE_WSI"
+DESC_USEGAMESCOPEWSI="This can be useful for some HDR options and for some DXVK v2.3 vsync optimisations"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230906-1 (gamescope-wsi-enable)"
+PROGVERS="v14.0.20230906-2 (gamescope-wsi-enable)"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -10407,7 +10407,7 @@ function GameScopeGui {
 						GSWAYLAND="${GSARR[55]}"
 						GSRT="${GSARR[56]}"
 						GSHDLS="${GSARR[57]}"
-						# GSARR[58] is the USEGAMESCOPEWSI checkbox
+						USEGAMESCOPEWSI="${GSARR[58]}"
 
 						# Build the GameScope arguments string
 						unset GAMESCOPE_ARGS

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230903-1"
+PROGVERS="v14.0.20230906-1 (gamescope-wsi-enable)"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -2739,6 +2739,7 @@ function setDefaultCfgValues {
 		if [ -z "$HARDARGS" ]							; then	HARDARGS="$NOPE"; fi
 		if [ -z "$USEGAMEMODERUN" ]						; then	USEGAMEMODERUN="0";	fi
 		if [ -z "$USEGAMESCOPE" ]						; then	USEGAMESCOPE="0"; fi
+		if [ -z "$USEGAMESCOPEWSI" ]					; then  USEGAMESCOPEWSI="0"; fi
 		if [ -z "$GAMESCOPE_ARGS" ]						; then	GAMESCOPE_ARGS="--"; fi
 		if [ -z "$USEOBSCAP" ]							; then	USEOBSCAP="0"; fi
 		if [ -z "$USEZINK" ]							; then	USEZINK="0"; fi
@@ -10329,6 +10330,7 @@ function GameScopeGui {
 			--field="$GUI_GSWAYLAND!$DESC_GSWAYLAND ('GSWAYLAND')":CHK "$GSWAYLAND" \
 			--field="$GUI_GSRT!$DESC_GSRT ('GSRT')":CHK "$GSRT" \
 			--field="$GUI_GSHDLS!$DESC_GSHDLS ('GSHDLS')":CHK "$GSHDLS" \
+			--field="$GUI_USEGAMESCOPEWSI!$DESC_USEGAMESCOPEWSI ('USEGAMESCOPEWSI')":CHK "$USEGAMESCOPEWSI" \
 			--button="$BUT_CAN:0" --button="$BUT_DGM:2" --button="$BUT_DONE:4" "$GEOM"
 			)"
 			case $? in
@@ -10405,6 +10407,7 @@ function GameScopeGui {
 						GSWAYLAND="${GSARR[55]}"
 						GSRT="${GSARR[56]}"
 						GSHDLS="${GSARR[57]}"
+						# GSARR[58] is the USEGAMESCOPEWSI checkbox
 
 						# Build the GameScope arguments string
 						unset GAMESCOPE_ARGS
@@ -10558,7 +10561,9 @@ function GameScopeGui {
 						touch "$FUPDATE"
 						updateConfigEntry "GAMESCOPE_ARGS" "$GAMESCOPE_ARGS" "$STLGAMECFG"						
 						touch "$FUPDATE"
-						updateConfigEntry "USEGAMESCOPE" "$USEGAMESCOPE" "$STLGAMECFG"						
+						updateConfigEntry "USEGAMESCOPE" "$USEGAMESCOPE" "$STLGAMECFG"
+						touch "$FUPDATE"
+						updateConfigEntry "USEGAMESCOPEWSI" "$USEGAMESCOPEWSI" "$STLGAMECFG"  # GAMESCOPE_WSI_ENABLE=1 option, since its an env var and not a gamescope flag we save it to game config
 					}
 				;;	
 			esac
@@ -11225,6 +11230,11 @@ function setCommandLaunchVars {
 				USEGAMESCOPE=0
 			fi
 		else
+			# Enable the ENABLE_GAMESCOPE_WSI environment variable if checkbox is enabled on GameScopeGui
+			if [ "$USEGAMESCOPEWSI" -eq 1 ]; then
+				export ENABLE_GAMESCOPE_WSI=1
+			fi
+
 			GSC="$(command -v "$GAMESCOPE")"
 			
 			gameScopeArgs "$GAMESCOPE_ARGS"  # Create GameScope args array - Is called twice because we call `setCommandLaunchVars` above and in `buildCustomCmdLaunch` it seems

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230906-2 (gamescope-wsi-enable)"
+PROGVERS="v14.0.20230906-1"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"


### PR DESCRIPTION
This can be used by DXVK v2.3 for some Vulkan optimisations when disabling vsync, as well as some HDR options within GameScope it looks like.

This still needs testing.

TODO:
- [x] Test this change (i.e. make sure it doesn't break any existing GameScope stuff, can't actually test the functionality)
- [x] Update langfiles