### PR TITLE
Add Non-Steam Game: Fix Non-Steam AppID Generation

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230915-1 (ansg-writeout-appid)"
+PROGVERS="v14.0.20230915-1"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230912-1"
+PROGVERS="v14.0.20230915-1 (ansg-writeout-appid)"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -22189,13 +22189,60 @@ function addNonSteamGame {
 		echo -n "$1" | gzip -c | tail -c 8 | od -An -N 4 -tx4
 	}
 
-	function dec2hex {
-		 printf '%x\n' "$1"
-	}
+
 
 	function hex2dec {
 		printf "%d\n" "0x${1#0x}"
 	}
+
+
+	## Notes on how Non-Steam AppIDs work, because it took me almost a year to figure this out
+	## ----------------------
+	## Steam stores shortcuts in a binary file called 'shortcuts.vdf', stored in SROOT/userdata/<id>/config
+	## This file stores information about Steam shortcuts, with many values being written out in hex, such as the Steam AppID and boolean values
+	##
+	## Non-Steam Game AppIDs are 32bit little-endian (reverse byte order) signed integers, stores as hexidecimal
+	## This AppID is probably generated using some combination of the AppName and Exe with a crc32 generated from them, but it can actually be anything
+	## Steam likely does things this way in an attempt to ensure "uniqueness" among entries. Projects like Steam-ROM-Manager do the same thing likely for similar reasons
+	##
+	## In our case, for simplicity, we're just going to generate a random 32bit signed integer, which we'll then convert to hex to store in the AppID file
+	## We can also convert this to an unsigned 32bit integer to get the AppID used for grids and other things, the unsigned int is just what Steam stores
+	##
+	## Though we can write any AppID we want, invalid ones (i.e. big endian hex) will be rejected by Steam and it will overwrite the generated AppID!
+	##
+	## We can later re-use these functions to do several things:
+	## - Check for and remove stray STL configs for no longer stored Non-Steam Game AppIDs (if we had Non-Steam Games we previously used with STL that we no longer use, we can remove these configs in case there is a conflict in future) 
+	## ----------------------
+
+	### BEGIN MAGIC APPID FUNCTIONS
+	## ----------
+	# Generate random signed 32bit integer which can be converted into hex, using the first argument (AppName and Exe fields) as seed (in an attempt to reduce the chances of the same AppID being generated twice)
+	function generateShortcutVDFAppId {
+		echo "-$( shuf -i 99999999-999999999 -n 1 --random-source=<(echo -n "$1") )"
+	}
+
+	function dec2hex {
+		printf '%x\n' "$1" | cut -c 9-  # This cut removes the 'ffffffff' from the string (represents the sign for the signed int) and starts from the 9th character onward 
+	}
+
+	# Takes a big-endian ("normal") hexidecimal number and converts it to little-endian (reverse byte order)
+	function bigToLittleEndian {
+		echo -n "$1" | tac -rs .. | tr -d '\n'
+		# echo -n "$1" | tac -rs .. | echo "$(tr -d '\n')"
+	}
+
+	# Takes an signed 32bit integer and converts it to a 4byte little-endian hex number
+	function generateShortcutVDFHexAppId {
+		bigToLittleEndian "$( dec2hex "$1" )"
+	}
+
+	# Takes an signed 32bit integer and converts it to an unsigned 32bit integer 
+	function generateShortcutGridAppId {
+		echo $(( $1 & 0xFFFFFFFF ))
+	}
+	## ----------
+	### END MAGIC APPID FUNCTIONS
+
 
 	function splitTags {
 		mapfile -d "," -t -O "${#TAGARR[@]}" TAGARR < <(printf '%s' "$1")
@@ -22206,7 +22253,7 @@ function addNonSteamGame {
 		done
 	}
 
-	NOSTHIDE=0
+	NOSTHIDE=0  # Does hide still work? Didn't seem to in my tests
 	NOSTADC=1
 	NOSTAO=1
 	NOSTVR=0
@@ -22264,15 +22311,21 @@ function addNonSteamGame {
 			NOSTGICONPATH="$STLICON"
 		fi
 
-		# AppID for Non-Steam Games in shortcuts.vdf is stored as 4-byte little endian integer by Steam
-		# No idea how to extract it using Bash, but there are various working Python implementations
-
-		NOSTAIDRHX="$(printf "%03x%03x%02x\n" $((RANDOM%4096)) $((RANDOM%4096)) $((RANDOM%256)))"
-		NOSTAID="$(hex2dec "$NOSTAIDRHX")"
-		NOSTAIDHX="\x$(awk '{$1=$1}1' FPAT='.{2}' OFS="\\\x" <<< "$NOSTAIDRHX")"
+		## ----
+		## These AppIDs are not necessarily guaranteed to be unique, such as if the user tries to add the same game twice or something
+		## Therefore, perhaps in future we could do a stricter check by attempting to parse the shortcuts.vdf file and re-generating the AppID if it already exists
+		## This could be expensive if the file is long, but a potential future enhancement all the same!
+		## ----
+		NOSTAIDVDF="$( generateShortcutVDFAppId "${NOSTAPPNAME}${NOSTEXEPATH}" )"  # This is the signed integer AppID that will be stored in the VDF as hexidecimal - ex: -598031679
+		NOSTAIDVDFHEX="$( generateShortcutVDFHexAppId "$NSGAID_S2KK" )"  # This is the 4byte little-endian hexidecimal of the above 32bit signed integer, which we write out to the binary VDF - ex: c1c25adc
+		NOSTAIDVDFHEXFMT="\x$(awk '{$1=$1}1' FPAT='.{2}' OFS="\\\x" <<< "$NOSTAIDVDFHEX")"  # This is the binary-formatted string hex of the above which we actually write out - ex: \xc1\xc2\x5a\xdc
+		NOSTAIDGRID="$( generateShortcutGridAppId "$NSGAID_S2KK" )"  # This is the unsigned 32bit ingeger version of "$NOSTAIDVDF", which is used as the AppID for Steam artwork ("grids"), as well as for our shortcuts
 
 		writelog "INFO" "${FUNCNAME[0]} - === Adding new $NSGA ==="
-		writelog "INFO" "${FUNCNAME[0]} - AppID: '${NOSTAID}'"
+		writelog "INFO" "${FUNCNAME[0]} - Signed Integer Shortcut AppID: '${NOSTAIDVDF}'"
+		writelog "INFO" "${FUNCNAME[0]} - 4byte Little-Endian Hex AppID: '${NOSTAIDVDFHEX}'"
+		writelog "INFO" "${FUNCNAME[0]} - Binary-formatted 4byte Little-Endian AppID: '${NOSTAIDVDFHEXFMT}'"
+		writelog "INFO" "${FUNCNAME[0]} - Unsigned Integer Shortcut AppID (used for artwork): '${NOSTAIDGRID}'"
 		writelog "INFO" "${FUNCNAME[0]} - App Name: '${NOSTAPPNAME}'"
 		writelog "INFO" "${FUNCNAME[0]} - Exe Path: '${NOSTEXEPATH}'"
 		writelog "INFO" "${FUNCNAME[0]} - Start Dir: '${NOSTSTDIR}'"
@@ -22299,9 +22352,14 @@ function addNonSteamGame {
 
 		writelog "INFO" "${FUNCNAME[0]} - Adding new set '$NEWSET'"
 
+		# DEBUGNSGAID="bd05f6fe"
+		# DEBUGNSGAIDESC="\x$(awk '{$1=$1}1' FPAT='.{2}' OFS="\\\x" <<< "$DEBUGNSGAID")"
+
 		{
 		printf '\x00%s\x00' "$NEWSET"
-		printf '\x02%s\x00%b' "appid" "$NOSTAIDHX"
+		printf '\x02%s\x00%b' "appid" "$NSGAIDHX_S2KK_FMT"
+		# printf '\x02%s\x00%b' "appid" "$NOSTAIDHX"
+		# printf '\x02%s\x00%b' "appid" "$DEBUGNSGAIDESC"
 		printf '\x01%s\x00%s\x00' "appname" "$NOSTAPPNAME"
 		printf '\x01%s\x00%s\x00' "Exe" "$NOSTEXEPATH"
 		printf '\x01%s\x00%s\x00' "StartDir" "$NOSTSTDIR"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -22214,6 +22214,7 @@ function addNonSteamGame {
 	## - Check for and remove stray STL configs for no longer stored Non-Steam Game AppIDs (if we had Non-Steam Games we previously used with STL that we no longer use, we can remove these configs in case there is a conflict in future) 
 	## ----------------------
 
+
 	### BEGIN MAGIC APPID FUNCTIONS
 	## ----------
 	# Generate random signed 32bit integer which can be converted into hex, using the first argument (AppName and Exe fields) as seed (in an attempt to reduce the chances of the same AppID being generated twice)
@@ -22228,7 +22229,6 @@ function addNonSteamGame {
 	# Takes a big-endian ("normal") hexidecimal number and converts it to little-endian (reverse byte order)
 	function bigToLittleEndian {
 		echo -n "$1" | tac -rs .. | tr -d '\n'
-		# echo -n "$1" | tac -rs .. | echo "$(tr -d '\n')"
 	}
 
 	# Takes an signed 32bit integer and converts it to a 4byte little-endian hex number
@@ -22317,9 +22317,9 @@ function addNonSteamGame {
 		## This could be expensive if the file is long, but a potential future enhancement all the same!
 		## ----
 		NOSTAIDVDF="$( generateShortcutVDFAppId "${NOSTAPPNAME}${NOSTEXEPATH}" )"  # This is the signed integer AppID that will be stored in the VDF as hexidecimal - ex: -598031679
-		NOSTAIDVDFHEX="$( generateShortcutVDFHexAppId "$NSGAID_S2KK" )"  # This is the 4byte little-endian hexidecimal of the above 32bit signed integer, which we write out to the binary VDF - ex: c1c25adc
+		NOSTAIDVDFHEX="$( generateShortcutVDFHexAppId "$NOSTAIDVDF" )"  # This is the 4byte little-endian hexidecimal of the above 32bit signed integer, which we write out to the binary VDF - ex: c1c25adc
 		NOSTAIDVDFHEXFMT="\x$(awk '{$1=$1}1' FPAT='.{2}' OFS="\\\x" <<< "$NOSTAIDVDFHEX")"  # This is the binary-formatted string hex of the above which we actually write out - ex: \xc1\xc2\x5a\xdc
-		NOSTAIDGRID="$( generateShortcutGridAppId "$NSGAID_S2KK" )"  # This is the unsigned 32bit ingeger version of "$NOSTAIDVDF", which is used as the AppID for Steam artwork ("grids"), as well as for our shortcuts
+		NOSTAIDGRID="$( generateShortcutGridAppId "$NOSTAIDVDF" )"  # This is the unsigned 32bit ingeger version of "$NOSTAIDVDF", which is used as the AppID for Steam artwork ("grids"), as well as for our shortcuts
 
 		writelog "INFO" "${FUNCNAME[0]} - === Adding new $NSGA ==="
 		writelog "INFO" "${FUNCNAME[0]} - Signed Integer Shortcut AppID: '${NOSTAIDVDF}'"
@@ -22352,14 +22352,9 @@ function addNonSteamGame {
 
 		writelog "INFO" "${FUNCNAME[0]} - Adding new set '$NEWSET'"
 
-		# DEBUGNSGAID="bd05f6fe"
-		# DEBUGNSGAIDESC="\x$(awk '{$1=$1}1' FPAT='.{2}' OFS="\\\x" <<< "$DEBUGNSGAID")"
-
 		{
 		printf '\x00%s\x00' "$NEWSET"
-		printf '\x02%s\x00%b' "appid" "$NSGAIDHX_S2KK_FMT"
-		# printf '\x02%s\x00%b' "appid" "$NOSTAIDHX"
-		# printf '\x02%s\x00%b' "appid" "$DEBUGNSGAIDESC"
+		printf '\x02%s\x00%b' "appid" "$NOSTAIDVDFHEXFMT"
 		printf '\x01%s\x00%s\x00' "appname" "$NOSTAPPNAME"
 		printf '\x01%s\x00%s\x00' "Exe" "$NOSTEXEPATH"
 		printf '\x01%s\x00%s\x00' "StartDir" "$NOSTSTDIR"


### PR DESCRIPTION
Part of work for #738, at long last!

We need to generate a 4byte little endian hex from a signed 32bit integer. This is what gets written to the shortcuts.vdf file. Steam will reject the AppID if it is not in this format, and will overwrite it.

This fixes the AppID generation, allowing us to 'predict' the AppID and will allow for implementing Non-Steam Game artwork selection.

## Implementation
*(A more thorough explanation of how Steam stores Non-Steam AppIDs can be found at https://github.com/sonic2kk/steamtinkerlaunch/issues/738#issuecomment-1720263749)*

It was discovered that the shortcut AppID is not actually generated by Steam itself, it can be anything so long as it is written out to the `shortcuts.vdf` file as a 4byte little endian hexadecimal representation of a signed 32bit integer. We aren't currently doing this, we're generating a random integer, converting it to hex, and attempting to write that out, which is why the AppID is always overwritten.

To fix this, essentially we have to generate a random nine-digit negative number and write that out as little-endian hex. Numerous functions were created to do this, but I'll explain the overall process here.

To start, we use `shuf` with a seed based on an optional argument to generate our signed 32bit integer. For our seed, we pass it a seed of the EXE name and path to it (ex: `Bad Piggies/home/Gaben/Games/Bad Piggies`), though the seed is an optional component to this function. Since `shuf` can't have a signed range, we cheat and add a `-` in front. This AppID is the decimal representation of what gets stored as a shortcut AppID in the `shortcuts.vdf` file (this is how the Python VDF library displays it, for example).

Once we have this signed integer, we need to convert it to a 4byte little-endian hexadecimal number. Since the `shortcuts.vdf` file is a binary file, it needs the value in hex representation. We first convert the signed integer to hex, and then convert that hex from big endian to little endian (which is basically the reverse byte order, this [Integer Encoder](https://cryptii.com/pipes/integer-encoder) website is very useful for checking out converting integers been signed, unsigned, hex, big endian, and little endian).

This value then needs some formatting to prefix each byte with `\x`, which Frostworx already wrote code for. This ensures it's written out to the binary file correctly. Once we do this, we've successfully written out our own custom AppID to the `shortcuts.vdf` file!

One final step which is useful for #738 specifically, is converting from our initial signed integer to unsigned. This unsigned integer is the one used to set the game artwork in the `/path/to/steamroot/userdata/<userid>/config/grid` folder, allowing that feature proposal to be implemented since we now have a knowable AppID.

## Future Implementations
This opens the door to various other features, one main feature that comes to mind is the ability to remove game configs for Non-Steam games which are no longer on Steam. For example adding a game shortcut to Steam, using STL with it, and then removing the game. That shortcut is going to hang around!

We can check if AppIDs over a certain length are in the `shortcuts.vdf` file, and if not, we can assume they were removed shortcuts, and remove these config files. We could also implement something similar for `compatdata` directories, as Steam does not clean these up. These compatdata directories are always stored on the root Steam install's `steamapps`, so we can simply check for and remove these folders.

Of course, both of these features should be implemented as commands with warnings, as checking based on AppID length is not the strongest test, but it should work for the meantime.

<hr>

Pending a tiny bit of further testing on a last-minute change to appease ShellCheck, and a version bump, this is ready to be merged!