### PR TITLE
Set Game Art: Refactor copy method logic

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230916-2 (setgameart-logicimprove)"
+PROGVERS="v14.0.20230916-2"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230916-1"
+PROGVERS="v14.0.20230916-2 (setgameart-logicimprove)"
 PROGCMD="${0##*/}"
 SHOSTL="stl"
 GHURL="https://github.com"
@@ -4060,14 +4060,7 @@ function setGameArtGui {
 			SGATENFOOT="${SGASETARR[4]}"
 			SGACOPYMETHOD="${SGASETARR[5]}"
 
-			## TODO can we refactor this to take a string parameter? e.g. "--link" -- It looks like that might work from testing
-			if [ "$SGACOPYMETHOD" = "link" ]; then
-				setGameArt "$1" --hero="$SGAHERO" --logo="$SGALOGO" --boxart="$SGABOXART" --tenfoot="$SGATENFOOT" --link
-			elif [ "$SGACOPYMETHOD" = "move" ]; then
-				setGameArt "$1" --hero="$SGAHERO" --logo="$SGALOGO" --boxart="$SGABOXART" --tenfoot="$SGATENFOOT" --move
-			else  # Default to copy
-				setGameArt "$1" --hero="$SGAHERO" --logo="$SGALOGO" --boxart="$SGABOXART" --tenfoot="$SGATENFOOT" --copy
-			fi
+			setGameArt "$1" --hero="$SGAHERO" --logo="$SGALOGO" --boxart="$SGABOXART" --tenfoot="$SGATENFOOT" "--${SGACOPYMETHOD}"
 	esac
 }
 


### PR DESCRIPTION
Improves on the logic for how we choose the copy method for setting game artwork. We can now just use `"--${flagvar}"` instead of having an ugly if statement to check this.

This potential improvement was discovered and documented in #903, and has now been implemented after verifying that it works.