### PR TITLE
ReShade + SpecialK: Automatically export DLL names

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230926-1"
+PROGVERS="v14.0.20230927-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -9066,8 +9066,8 @@ function checkReshade {
 				installReshade F
 			fi
 
-			writelog "INFO" "${FUNCNAME[0]} - Setting WINEDLLOVERRIDES for ${RESH}: dxgi=n,b;d3d9=n,b;${D3D47//.dll}=n,b;d3d11=n,b;opengl32=n,b"
-			export WINEDLLOVERRIDES="$WINEDLLOVERRIDES;dxgi=n,b;d3d9=n,b;${D3D47//.dll}=n,b;d3d11=n,b;opengl32=n,b"
+			writelog "INFO" "${FUNCNAME[0]} - Setting WINEDLLOVERRIDES for ${RESH}: dxgi=n,b;d3d9=n,b;${D3D47//.dll}=n,b;d3d11=n,b;opengl32=n,b;${RESHADEDLLNAME//.dll}=n,b"
+			export WINEDLLOVERRIDES="$WINEDLLOVERRIDES;dxgi=n,b;d3d9=n,b;${D3D47//.dll}=n,b;d3d11=n,b;opengl32=n,b;${RESHADEDLLNAME//.dll}=n,b"
 		fi
 	else	
 		if [ -f "$FRSINI" ]; then
@@ -9424,6 +9424,10 @@ function useSpecialK {
 			removeSpekDlls
 		fi
 	fi
+
+	SPEKDLLEXPORTNAME="$( basename "$SPEKDST" )"  # Make sure we use an actual name and not 'autp'
+	writelog "INFO" "${FUNCNAME[0]} - Setting WINEDLLOVERRIDES for ${RESH}: dxgi=n,b;d3d9=n,b;${D3D47//.dll}=n,b;d3d11=n,b;opengl32=n,b;${SPEKDLLEXPORTNAME//.dll}=n,b"
+	export WINEDLLOVERRIDES="$WINEDLLOVERRIDES;dxgi=n,b;d3d9=n,b;${D3D47//.dll}=n,b;d3d11=n,b;opengl32=n,b;${SPEKDLLEXPORTNAME//.dll}=n,b"
 }
 
 function removeSpekDlls {

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230927-1"
+PROGVERS="v14.0.20230927-2 (export-dlloverride-spek-resh)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -9360,6 +9360,10 @@ function useSpecialK {
 				echo "$SPEKDDIR/$SPEKPDB" >> "$SPEKENA"
 			fi
 			prepareSpecialKIni  # Moved here so this is created only once we confirm SpecialK can be installed
+
+			SPEKDLLEXPORTNAME="$( basename "$SPEKDST" )"  # Make sure we use an actual name and not 'autp'
+			writelog "INFO" "${FUNCNAME[0]} - Setting WINEDLLOVERRIDES for ${SPEK}: dxgi=n,b;d3d9=n,b;${D3D47//.dll}=n,b;d3d11=n,b;opengl32=n,b;${SPEKDLLEXPORTNAME//.dll}=n,b"
+			export WINEDLLOVERRIDES="$WINEDLLOVERRIDES;dxgi=n,b;d3d9=n,b;${D3D47//.dll}=n,b;d3d11=n,b;opengl32=n,b;${SPEKDLLEXPORTNAME//.dll}=n,b"
 		elif [ "$SPEKDLLCONFLICTFOUND" -eq 0 ] && [ "$SHOULDINSTALLSPEK" -eq 0 ]; then
 			# In this scenario, SpecialK is already installed so we don't need to install it
 			# So write out the DLL name to the SPEKENA file to ensure we don't end up with a blank file
@@ -9424,10 +9428,6 @@ function useSpecialK {
 			removeSpekDlls
 		fi
 	fi
-
-	SPEKDLLEXPORTNAME="$( basename "$SPEKDST" )"  # Make sure we use an actual name and not 'autp'
-	writelog "INFO" "${FUNCNAME[0]} - Setting WINEDLLOVERRIDES for ${RESH}: dxgi=n,b;d3d9=n,b;${D3D47//.dll}=n,b;d3d11=n,b;opengl32=n,b;${SPEKDLLEXPORTNAME//.dll}=n,b"
-	export WINEDLLOVERRIDES="$WINEDLLOVERRIDES;dxgi=n,b;d3d9=n,b;${D3D47//.dll}=n,b;d3d11=n,b;opengl32=n,b;${SPEKDLLEXPORTNAME//.dll}=n,b"
 }
 
 function removeSpekDlls {

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230927-2 (export-dlloverride-spek-resh)"
+PROGVERS="v14.0.20230926-2"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"


### PR DESCRIPTION
One more piece of work for #894.

This PR adds the SpecialK and ReShade DLL names to the `WINEDLLOVERRIDES`, without any `.dll` extension if it exists. This means custom DLL name should be loaded by the game without any DLL overrides having to be set by the user. Unsure why this wasn't done in #881, but because of that we didn't do it in #912. I guess I thought it would be more complex than this :sweat_smile: 

The logic here is a bit messy, as it will export DLL names twice in some scenarios. If we leave the DLL names as defaults, for example `dxgi.dll`, then it will technically be in `WINEDLLOVERRIDES` twice. This shouldn't cause issues, though. Logging just might look a little odd at first :-)

The DLLs will only be exported for SpecialK if it actually reaches the block for installation, so they won't be exported in any other case. They were not exported before afaik so I guess the game just picked it up manually, hopefully this won't break anything :-)

<hr>

This is mostly untested, so will need more testing to ensure this doesn't break anything.