### PR TITLE
Add Non-Steam Game: Fix StartDir when using GUI

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231019-1"
+PROGVERS="v14.0.20231019-2"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -23298,10 +23298,16 @@ function addNonSteamGame {
 				NOSTAPPNAME="${i#*=}"
 				shift ;;
 			-ep=*|--exepath=*)
-				QEP="${i#*=}"; NOSTEXEPATH="\"$QEP\""
+				QEP="${i#*=}";
+				if [ -n "$QEP" ]; then
+					NOSTEXEPATH="\"$QEP\""
+				fi
 				shift ;;
 			-sd=*|--startdir=*)
-				QSD="${i#*=}"; NOSTSTDIR="\"$QSD\""
+				QSD="${i#*=}"
+				if [ -n "$QSD" ]; then
+					NOSTSTDIR="\"$QSD\""
+				fi
 				shift ;;
 			-ip=*|--iconpath=*)
 				NOSTICONPATH="${i#*=}"
@@ -23397,7 +23403,7 @@ function addNonSteamGame {
 			NOSTAPPNAME="${QEP##*/}"
 		fi
 
-		if [ -z "${NOSTSTDIR}" ]; then
+		if [ -z "${NOSTSTDIR}" ] || [ "${NOSTSTDIR}" = "\"\"" ]; then
 			QSD="$(dirname "$QEP")"; NOSTSTDIR="\"$QSD\""
 		fi
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -23305,7 +23305,7 @@ function addNonSteamGame {
 				shift ;;
 			-sd=*|--startdir=*)
 				QSD="${i#*=}"
-				if [ -n "$QSD" ]; then
+				if [ -n "$QSD" ] && [ -d "$QSD" ]; then
 					NOSTSTDIR="\"$QSD\""
 				fi
 				shift ;;
@@ -23403,7 +23403,7 @@ function addNonSteamGame {
 			NOSTAPPNAME="${QEP##*/}"
 		fi
 
-		if [ -z "${NOSTSTDIR}" ] || [ "${NOSTSTDIR}" = "\"\"" ]; then
+		if [ -z "${NOSTSTDIR}" ] || [ ! -d "${NOSTSTDIR}" ]; then
 			QSD="$(dirname "$QEP")"; NOSTSTDIR="\"$QSD\""
 		fi
 


### PR DESCRIPTION
Fixes a problem found when investigating for #941.

## Problem
When adding Non-Steam games from the GUI, we still pass `-sd` even though it's blank, meaning:
- `${i#*=}` is always empty (``)
- We always set `NOSTEXEPATH` to `""` (which the blank `$QEP` variable wrapped in quotes)
- Because of this, the check later on for `-z "${NOSTEXEDIR}"` will always fail, because it's set to `""` (a set of empty quotes).

When adding games from the commandline, this works because under normal circumstances, `-sd|--start-dir` is not passed. However, if a user passed `--start-dir=""`, then the problem would be the same as above on the GUI.

This means when adding Non-Steam games from the GUI, we end up always writing out `""` as the StartDir if the user didn't specify one, whereas we should have been writing out the directory of the EXE. For example, `/home/gaben/Games/Sandtrix/sandtrix.exe` should have set the StartDir as `/home/gaben/Games/Sandtrix`, but it isn't - It's using `""`.

The problem with this is that some games expect to have their working/launch directory be the same as the directory that the EXE is inside of. If StartDir is not set properly, Steam cannot `chdir` into the directory, and although the game will still launch it will not be using the EXE dir that the game might expect.

Steam's default behaviour is also to use the EXE directory as StartDir when adding Non-Steam games from the client, so we should be following this behaviour regardless (although we were meant to be doing this in the first place, this is a fix for existing functionality).

## Solution
The solution is to check to make sure `--start-dir` is actually defined and actually a directory, before setting it as the StartDir to use. This sanity check makes sure we don't write out invalid path values when adding the Non-Steam Game.

Because of this check, we will also now correctly write out the default value for StartDir, it resolves the issue. Now we match the Steam default behaviour.

<hr>

Tested this and it should work, so we should be good to merge right away.