### PR TITLE
ModOrganizer 2: Add experimental repair command

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231021-1 (mo2-repair-experimental)"
+PROGVERS="v14.0.20231021-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231020-1"
+PROGVERS="v14.0.20231021-1 (mo2-repair-experimental)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -21790,6 +21790,11 @@ function commandline {
 				fi
 			elif [ "$2" == "getpfx" ] || [ "$2" == "gp" ]; then
 				echo "$MO2COMPDATA/pfx"
+			elif [ "$2" == "repairpfx" ]; then
+				writelog "INFO" "${FUNCNAME[0]} - STUB"
+				# EXPERIMENTAL REPAIR OPTION
+				# setMO2Vars
+				# STEAM_COMPAT_DATA_PATH="$MO2COMPDATA" "$get_mo2_proton_script" run wine
 			elif [ "$2" == "winecfg" ]; then
 				mo2Winecfg
 			elif [ "$2" == "winetricks" ] || [ "$2" == "wt" ]; then

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -21791,10 +21791,16 @@ function commandline {
 			elif [ "$2" == "getpfx" ] || [ "$2" == "gp" ]; then
 				echo "$MO2COMPDATA/pfx"
 			elif [ "$2" == "repairpfx" ]; then
-				writelog "INFO" "${FUNCNAME[0]} - STUB"
 				# EXPERIMENTAL REPAIR OPTION
-				# setMO2Vars
-				# STEAM_COMPAT_DATA_PATH="$MO2COMPDATA" "$get_mo2_proton_script" run wine
+				writelog "INFO" "${FUNCNAME[0]} - Attempting to repair ModOrganizer 2 prefix using experimental repair option"
+				writelog "INFO" "${FUNCNAME[0]} - This runs a basic Proton command in the game prefix in an attempt to repair/update corrupted/outdated files in the prefix"
+				writelog "INFO" "${FUNCNAME[0]} - Attempting to repair ModOrganizer 2 prefix with 'STEAM_COMPAT_DATA_PATH=\"$MO2COMPDATA\" \"$MO2RUNPROT\" run wine'"
+
+				echo "WARNING: This option is experimental and intended for use to fix kernel32.dll-related errors, here be dragons!"
+				echo "Attempting to repair ModOrganizer 2 prefix with 'STEAM_COMPAT_DATA_PATH=\"$MO2COMPDATA\" \"$MO2RUNPROT\" run wine'"
+				STEAM_COMPAT_DATA_PATH="$MO2COMPDATA" "$MO2RUNPROT" run wine
+				writelog "INFO" "${FUNCNAME[0]} - Finished attempting to repair ModOrganizer 2 prefix"
+				echo "Done. If there are any errors above, repair probably didn't succeed. If there are no errors and the prefix is still broken, try running something with Proton in the prefix using something similar to the command above."
 			elif [ "$2" == "winecfg" ]; then
 				mo2Winecfg
 			elif [ "$2" == "winetricks" ] || [ "$2" == "wt" ]; then


### PR DESCRIPTION
This PR adds an experimental command for ModOrganizer 2, which attempts to repair a broken standalone MO2 prefix.

We run ModOrganizer 2 using a Wine command, but if the Proton version changes, there is a chance the prefix may break as well. The newer Proton version may not be compatible with the typical Wine entry point, `kernel32.dll`. This will result in an error along the lines of `wine: could not load kernel32.dll, status c0000135`. Even the status code here is typically the same.

We can fix this by running a Wine command using Proton, which will update the symlinked libraries to the ones used by the current Proton version. The command of choice used here was `wine` which doesn't do anything and exits quickly, so the command will look something like `STEAM_COMPAT_DATA_PATH="/home/gaben/.config/steamtinkerlaunch/mo2/compatdata" "/home/gaben/.local/share/Steam/compatibilitytools.d/GE-Proton8-20/proton" run wine`.

This does not happen with regular launches because we run in the game's prefix, which is repaired with Proton already. But the standalone MO2 compatdata does not get this luxury.

There may be a way to automate this in future, such as when the MO2 Proton version changes, or maybe we can switch over to using Proton to run MO2 directly at a later date. For now, this works and fixed the problem for me, so I think it could be useful for others to have this too.