### PR TITLE
Primerun: Ensure nvidia_icd.json is used

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231023-1"
+PROGVERS="v14.0.20231024-1 (primerun-change)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -11904,6 +11904,7 @@ function setCommandLaunchVars {
 		export __NV_PRIME_RENDER_OFFLOAD=1
 		export __VK_LAYER_NV_optimus=NVIDIA_only
 		export __GLX_VENDOR_LIBRARY_NAME=nvidia
+		export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json
 	fi
 
 	# This could be expanded in future as a general option to force Wayland for games/engines that support it, e.g. '-wayland' flag for unity

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231024-1 (primerun-change)"
+PROGVERS="v14.0.20231024-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"


### PR DESCRIPTION
Should fix #953.

When `USEPRIMERUN` is on, we export several environment variables. But if the `nvidia_icd.json` is not set in the current environment's `VK_ICD_FILENAMES`, it will not be able to use the Nvidia GPU. For cases likee this, we should explicitly export `nvidia_icd.json`.

The fix for this was given by OP in #953 (they informed which environment variable to use), this PR just applies it in the appropriate spot in the code.

This path is not likely to change, and if other custom ones are necessary, a user can manually set these in their STL env variable config file.

Putting this up as a branch in case this fix is not sufficient, and we have to make other changes.