### PR TITLE
SteamGridDB: Add timeout and retries to SteamGridDB Artwork Fetching

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231024-2"
+PROGVERS="v14.0.20231025-1 (sgdb-retry-timeout)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -161,6 +161,8 @@ STLQUIET=0
 SLRAID="1070560"  # Hardcoded SLR AppID for native games -- See `setSLRReap`
 DEFWINEDPI="96"
 WINEDPIVALUES="${DEFWINEDPI}!120!150!240"
+SGDBTIMEOUT="15"
+SGDBRETRIES="5"
 
 ### default vars ###
 
@@ -1437,7 +1439,7 @@ function downloadArtFromSteamGridDB {
 
 		# TODO break into reusable function for both this and `getSGDBGameIDFromTitle`?
 		# If the whole batch has no grids we get a 404 and wget gives an error. --content-on-error ensures we still get the response json and the following logic still works
-		RESPONSE="$("$WGET" --content-on-error --header="Authorization: Bearer $SGDBAPIKEY" -q "$SGDB_ENDPOINT_STR" -O - 2> >(grep -v "SSL_INIT"))"
+		RESPONSE="$("$WGET" --timeout="${SGDBTIMEOUT}" --tries="${SGDBRETRIES}" --content-on-error --header="Authorization: Bearer $SGDBAPIKEY" -q "$SGDB_ENDPOINT_STR" -O - 2> >(grep -v "SSL_INIT"))"
 		if ! "$JQ" -e '.success' 1> /dev/null <<< "$RESPONSE"; then
 			writelog "INFO" "${FUNCNAME[0]} - The server response wasn't 'success' for this batch of requested games."
 		fi
@@ -1647,7 +1649,7 @@ function getSGDBGameIDFromTitle {
 	if [ -n "$SGDBSEARCHNAME" ]; then
 		SGDBSEARCHENDPOINT="${BASESTEAMGRIDDBAPI}/search/autocomplete/${SGDBSEARCHNAME}"
 		if checkSGDbApi; then
-			SGDBSEARCHNAMERESP="$( "$WGET" --content-on-error --header="Authorization: Bearer $SGDBAPIKEY" -q "$SGDBSEARCHENDPOINT" -O - 2>  >(grep -v "SSL_INIT") )"
+			SGDBSEARCHNAMERESP="$( "$WGET" --timeout="${SGDBTIMEOUT}" --tries="${SGDBRETRIES}" --content-on-error --header="Authorization: Bearer $SGDBAPIKEY" -q "$SGDBSEARCHENDPOINT" -O - 2>  >(grep -v "SSL_INIT") )"
 			if "$JQ" -e '.success' 1> /dev/null <<< "$SGDBSEARCHNAMERESP"; then
 				if [ "$( "$JQ" '.data | length' <<< "$SGDBSEARCHNAMERESP" )" -gt 0 ]; then
 					SGDBSEARCH_FOUNDNAME="$( "$JQ" '.data[0].name' <<< "$SGDBSEARCHNAMERESP" )"


### PR DESCRIPTION
Another bit for #933.

This adds a timeout for SteamGridDB, and a specific amount of retries. The default timeout is `15` seconds, and the maximum number of retries is set to `5`.

The reason for this is `wget` will retry for 600 seconds by default. It will also infinitely retry. In testing I found there are intermittent failures when fetching artwork from SteamGridDB, where it will just hang (possibly related to my internet connection?).

A good use-case for this is when adding Non-Steam Games, even though you can Ctrl+C, this will end up corrupting the `shortcuts.vdf` and you will lose all your shortcuts. To prevent that case, and to hopefully retry and successfully download artwork, this change will allow for a timeout and retry. If wget fails after those 5 attempts it will move onto the next piece of artwork to download, or if it was the last artwork that it failed on, then it will just return and add the Steam shortcut as normal.

If artwork fails, this PR will be especially useful once we can get AppIDs for Non-Steam Games. The user can see the artwork failed to download and they can retry on the AppID.

<hr>

Shellcheck is green on this, but I want to do a little more testing before merging, probably tomorrow at this point.

TODO:
- [x] More testing
- [ ] Bump version