### PR TITLE
Add Non-Steam Game: Refactor Shortcut Entry Creation

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -23463,7 +23463,7 @@ function addNonSteamGame {
 				NOSTVR="$( checkValidVDFBoolean "${i#*=}" )"
 				shift ;;
 			-t=*|--tags=*)
-				NOSTTAGS="$( checkValidVDFBoolean "${i#*=}" )"
+				NOSTTAGS="${i#*=}"
 				shift ;;
 			-stllo=*|--stllaunchoption=*)
 				NOSTSTLLO="${i#*=}"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -23321,9 +23321,7 @@ function addNonSteamGame {
 	SCPATH="$STUIDPATH/config/$SCVDF"
 
 	function checkValidVDFBoolean {
-		if [ "$1" -eq 1 ] || [ "$1" -eq 0 ]; then
-			echo "$1"  # Only return value if 1 or 0, then other places can do "${var:-0}"
-		fi
+		[ "$1" -eq 1 ] || [ "$1" -eq 0 ] && echo "$1"
 	}
 
 	function getCRC {

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231031-2 (ansg-writeout-refactor)"
+PROGVERS="v14.0.20231031-4 (ansg-writeout-refactor)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -23347,7 +23347,6 @@ function addNonSteamGame {
 	##
 	## We can later re-use these functions to do several things:
 	## - Check for and remove stray STL configs for no longer stored Non-Steam Game AppIDs (if we had Non-Steam Games we previously used with STL that we no longer use, we can remove these configs in case there is a conflict in future)
-	## ----------------------
 
 	### BEGIN MAGIC APPID FUNCTIONS
 	## ----------
@@ -23642,9 +23641,9 @@ function addNonSteamGame {
 		# Regular artwork
 		notiShow "$NOTY_SGDBDL"
 
-		# The entered name to search on will take priority over the actual game EXE name, only one will be used and we will always prefer the entered custom name
-		# For example if a user naames their Non-Steam Game "The Elder Scrolls IV: Oblivion" but they enter a custom search name because they want artwork for "The Elder Scrolls IV: Oblivion Game of the Year Edition"
-		# If art is not found for the custom name, users should enter either the Steam AppID or the SteamGridDB Game ID to use as a fallback (Steam AppID will always be preferred because it will always be exact)
+		# The entered search name is prioritised over actual game EXE name, only one will be used and we will always prefer custom name
+		# Ex: user names Non-Steam Game "The Elder Scrolls IV: Oblivion" but they enter a custom search name because they want artwork for "The Elder Scrolls IV: Oblivion Game of the Year Edition"
+		# In case art is not found for the custom name, users should enter either the Steam AppID or the SteamGridDB Game ID to use as a fallback (Steam AppID will always be preferred because it will always be exact)
 		#
 		# Therefore, the order of priority for artwork searching is:
 		# 1. Name search (only ONE of the below will be used)
@@ -23693,7 +23692,6 @@ function addNonSteamGame {
 	fi
 
 	writelog "INFO" "${FUNCNAME[0]} - Adding new set '$NEWSET'"
-
 	{
 		printf '\x00%s\x00' "$NEWSET"
 		printf '\x02%s\x00%b' "appid" "$NOSTAIDVDFHEXFMT"
@@ -23738,7 +23736,6 @@ function addNonSteamGame {
 	fi
 
 	writelog "INFO" "${FUNCNAME[0]} - Finished adding new $NSGA"
-
 	SGACOPYMETHOD=""  # Unset doesn't work for some reason with '--flag'
 }
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231031-1"
+PROGVERS="v14.0.20231031-2 (ansg-writeout-refactor)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231031-4 (ansg-writeout-refactor)"
+PROGVERS="v14.0.20231101-1 (ansg-writeout-refactor)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -23704,10 +23704,10 @@ function addNonSteamGame {
 
 		# Before we had an ifelse for this, checking if the var -eq 1, but we can just write the value as-is to the VDF
 		# Use either the defined value, which should be 1 or 0, or default to 0
-		printf '\x02%s\x00\x0%s\x00\x00\x00' "IsHidden" "${NOSTHIDE:-0}"		
-		printf '\x02%s\x00\x0%s\x00\x00\x00' "AllowDesktopConfig" "${NOSTADC:-0}"
-		printf '\x02%s\x00\x0%s\x00\x00\x00' "AllowOverlay" "${NOSTAO:-0}"
-		printf '\x02%s\x00\x0%s\x00\x00\x00' "OpenVR" "${NOSTVR:-0}"
+		printf '\x02%s\x00%b\x00\x00\x00' "IsHidden" "\x0${NOSTHIDE:-0}"
+		printf '\x02%s\x00%b\x00\x00\x00' "AllowDesktopConfig" "\x0${NOSTADC:-0}"
+		printf '\x02%s\x00%b\x00\x00\x00' "AllowOverlay" "\x0${NOSTAO:-0}"
+		printf '\x02%s\x00%b\x00\x00\x00' "OpenVR" "\x0${NOSTVR:-0}"
 
 		printf '\x02%s\x00\x00\x00\x00\x00' "Devkit"
 		printf '\x01%s\x00\x00' "DevkitGameID"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231101-1 (ansg-writeout-refactor)"
+PROGVERS="v14.0.20231103-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -23335,9 +23335,8 @@ function addNonSteamGame {
 	## Notes on how Non-Steam AppIDs work, because it took me almost a year to figure this out
 	## ----------------------
 	## Steam stores shortcuts in a binary file called 'shortcuts.vdf', stored in SROOT/userdata/<id>/config
-	## This file stores information about Steam shortcuts, with many values being written out in hex, such as the Steam AppID and boolean values
 	##
-	## Non-Steam Game AppIDs are 32bit little-endian (reverse byte order) signed integers, stores as hexidecimal
+	## Non-Steam Game AppIDs are 32bit little-endian (reverse byte order) signed integers, stored as hexidecimal
 	## This AppID is probably generated using some combination of the AppName and Exe with a crc32 generated from them, but it can actually be anything
 	## Steam likely does things this way in an attempt to ensure "uniqueness" among entries. Projects like Steam-ROM-Manager do the same thing likely for similar reasons
 	##

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -23697,59 +23697,25 @@ function addNonSteamGame {
 		printf '\x01%s\x00%s\x00' "AppName" "$NOSTAPPNAME"
 		printf '\x01%s\x00%s\x00' "Exe" "$NOSTEXEPATH"
 		printf '\x01%s\x00%s\x00' "StartDir" "$NOSTSTDIR"
+		printf '\x01%s\x00%s\x00' "icon" "$NOSTICONPATH"
+		printf '\x01%s\x00%s\x00' "ShortcutPath" ""
+		printf '\x01%s\x00%s\x00' "LaunchOptions" "$NOSTLAOP"
 
-		if [ -n "$NOSTICONPATH" ]; then
-			printf '\x01%s\x00%s\x00' "icon" "$NOSTICONPATH"
-		else
-			printf '\x01%s\x00\x00' "icon"
-		fi
-
-		printf '\x01%s\x00\x00' "ShortcutPath"
-
-		if [ -n "$NOSTLAOP" ]; then
-			printf '\x01%s\x00%s\x00' "LaunchOptions" "$NOSTLAOP"
-		else
-			printf '\x01%s\x00\x00' "LaunchOptions"
-		fi
-
-		if [ "$NOSTHIDE" -eq 1 ]; then
-			printf '\x02%s\x00\x01\x00\x00\x00' "IsHidden"
-		else
-			printf '\x02%s\x00\x00\x00\x00\x00' "IsHidden"
-		fi
-
-		if [ "$NOSTADC" -eq 1 ]; then
-			printf '\x02%s\x00\x01\x00\x00\x00' "AllowDesktopConfig"
-		else
-			printf '\x02%s\x00\x00\x00\x00\x00' "AllowDesktopConfig"
-		fi
-
-		if [ "$NOSTAO" -eq 1 ]; then
-			printf '\x02%s\x00\x01\x00\x00\x00' "AllowOverlay"
-		else
-			printf '\x02%s\x00\x00\x00\x00\x00' "AllowOverlay"
-		fi
-
-		if [ "$NOSTVR" -eq 1 ]; then
-			printf '\x02%s\x00\x01\x00\x00\x00' "OpenVR"
-		else
-			printf '\x02%s\x00\x00\x00\x00\x00' "OpenVR"
-		fi
+		# Before we had an ifelse for this, checking if the var -eq 1, but we can just write the value as-is to the VDF
+		# Use either the defined value, which should be 1 or 0, or default to 0
+		printf '\x02%s\x00\x0%s\x00\x00\x00' "IsHidden" "${NOSTHIDE:-0}"		
+		printf '\x02%s\x00\x0%s\x00\x00\x00' "AllowDesktopConfig" "${NOSTADC:-0}"
+		printf '\x02%s\x00\x0%s\x00\x00\x00' "AllowOverlay" "${NOSTAO:-0}"
+		printf '\x02%s\x00\x0%s\x00\x00\x00' "OpenVR" "${NOSTVR:-0}"
 
 		printf '\x02%s\x00\x00\x00\x00\x00' "Devkit"
 		printf '\x01%s\x00\x00' "DevkitGameID"
 		printf '\x02%s\x00\x00\x00\x00\x00' "DevkitOverrideAppID"
-
 		printf '\x02%s\x00\x00\x00\x00\x00' "LastPlayTime"
 		printf '\x01%s\x00\x00' "FlatpakAppID"
 		printf '\x00%s\x00' "tags"
 		splitTags "$NOSTTAGS"
-		printf '\x08'
-		printf '\x08'
-
-		#file end:
-		printf '\x08'
-		printf '\x08'
+		printf '\x08\x08\x08\x08'
 	} >> "$SCPATH"
 
 	writelog "INFO" "${FUNCNAME[0]} - Finished writing out new Non-Steam Game Shortcut"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -23320,6 +23320,12 @@ function addNonSteamGame {
 	fi
 	SCPATH="$STUIDPATH/config/$SCVDF"
 
+	function checkValidVDFBoolean {
+		if [ "$1" -eq 1 ] || [ "$1" -eq 0 ]; then
+			echo "$1"  # Only return value if 1 or 0, then other places can do "${var:-0}"
+		fi
+	}
+
 	function getCRC {
 		echo -n "$1" | gzip -c | tail -c 8 | od -An -N 4 -tx4
 	}
@@ -23449,19 +23455,19 @@ function addNonSteamGame {
 				NOSTLAOP="${i#*=}"
 				shift ;;
 			-hd=*|--hide=*)
-				NOSTHIDE="${i#*=}"
+				NOSTHIDE="$( checkValidVDFBoolean "${i#*=}" )"
 				shift ;;
 			-adc=*|--allowdesktopconf=*)
-				NOSTADC="${i#*=}"
+				NOSTADC="$( checkValidVDFBoolean "${i#*=}" )"
 				shift ;;
 			-ao=*|--allowoverlay=*)
-				NOSTAO="${i#*=}"
+				NOSTAO="$( checkValidVDFBoolean "${i#*=}" )"
 				shift ;;
 			-vr=*|--openvr=*)
-				NOSTVR="${i#*=}"
+				NOSTVR="$( checkValidVDFBoolean "${i#*=}" )"
 				shift ;;
 			-t=*|--tags=*)
-				NOSTTAGS="${i#*=}"
+				NOSTTAGS="$( checkValidVDFBoolean "${i#*=}" )"
 				shift ;;
 			-stllo=*|--stllaunchoption=*)
 				NOSTSTLLO="${i#*=}"


### PR DESCRIPTION
Refactors how we generate shortcut entries to write out to `shortcuts.vdf`. This PR is in part motivated to simplify the codebase as well as reduce overall script size.

Instead of having a lot of if/else checks for whether to use `\0x01` or `\0x00`, we instead just printf regardless and if the value is blank, default to `0`. Then, to ensure the value is blank if it isn't 1 or 0 (since we can pass values on the commandline like `--hide="no please"`, anything that is passed to one of the following tags will be defaulted to blank, and so set as `0` in the `shortcuts.vdf`:
- `--hide`
- `--allowdesktopconf`
- `--allowoverlay`
- `--openvr`

I had originally wanted to change the usage to simply be `--hide`, and if the flag was present at all, set `NOSTHIDE=1`. But with how we use this function in `addNonSteamGameGUI`, that was going to require a lot of if/else checks, or some messy workarounds in that function when we call `addNonSteamGame`, so I didn't bother. In future if someone can figure out a clean way to do this, a PR would be weelcome!