### PR TITLE
VDF Parsing: Add More VDF Parsing Functions 

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -21804,7 +21804,27 @@ function commandline {
 		# Why are you looking here? :-)
 
 		# writelog "INFO" "${FUNCNAME[0]} - Stub"
-		dlX64Dbg
+		LCLCFGVDF="$STUIDPATH/config/localconfig bsak.vdf"
+		# getVdfSection "Apps" "" "" "$LCLCFGVDF"
+
+		SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/-222353304" "1" "$LCLCFGVDF" )"
+		# echo "$SHORTCUTLOCALCONFIGVDFSECTION"
+		editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "1" "$LCLCFGVDF"
+
+		# TESTVDF="$HOME/.local/share/Steam/config/config.vdf"
+		
+		# FOUNDSEC="$( getNestedVdfSection "Apps/-222353304" "1" "$LCLCFGVDF" )"
+		# FINDSECPROP="OverlayAppEnable"
+		# ORGSECPROP="$( trimWhitespaces "$( echo "${FOUNDSEC}" | grep "$FINDSECPROP" )" )"
+		# UPDATEDSECPROP="$( printf "\"%s\"\t\t\"%s\"" "$FINDSECPROP" "1" )"
+		# UPDATEDSEC="$( echo "${FOUNDSEC}" | sed "s/${ORGSECPROP}/${UPDATEDSECPROP}/g" )"
+
+		# echo "$ORGSECPROP"
+		# echo "$UPDATEDSECPROP"
+		# echo "$UPDATEDSEC"
+		# getNestedVdfSection "Steam/ShaderCacheManager/App/730" "" "$TESTVDF" 
+
+		# FOUNDVDFSECTION = editVdfSectionValue "$LCLCFGVDF" "Apps" "-222353304" "1" "OverlayAppEnable" "0"
 	elif [ "$1" == "mo2" ]; then
 		if [ -n "$2" ]; then
 			if [ "$2" == "download" ] || [ "$2" == "d" ]; then
@@ -22905,7 +22925,7 @@ function guessVdfIndent {
     BLOCKNAME="$( safequoteVdfBlockName "$1" )"  # Block to check the indentation level on
     VDF="$2"
 
-    grep -i "${BLOCKNAME}" "$VDF" | awk '{print gsub(/\t/,"")}'
+    grep -i "${BLOCKNAME}" "$VDF" | head -n1 | awk '{print gsub(/\t/,"")}'
 }
 
 ## Surround a VDF block name with quotes if it doesn't have any
@@ -22935,7 +22955,9 @@ function getVdfSection {
 
 	writelog "INFO" "${FUNCNAME[0]} - Searching for VDF block with name '$STARTPATTERN' in VDF file '$VDF'"
 
-    sed -n "/${INDENTEDSTARTPATTERN}/I,/^${INDENTEDENDPATTERN}/I p" "$VDF"
+	# TODO: the ^ match was added later on, ensure this doesn't break anything!
+    # TODO the { p; blah } was added later on, ensure this still works!
+	sed -n "/^${INDENTEDSTARTPATTERN}/I,/^${INDENTEDENDPATTERN}/I { p; /${INDENTEDENDPATTERN}/I q }" "$VDF"
 }
 
 ## Check if a VDF block (block_name) already exists inside a parent block (search_block)
@@ -22958,6 +22980,39 @@ function checkVdfSectionAlreadyExists {
 
     printf "%s" "$SEARCHBLOCKVDFSECTION" > "/tmp/tmp.vdf"
     getVdfSection "$BLOCKNAME" "" "" "/tmp/tmp.vdf" | grep -iq "$BLOCKNAME"
+}
+
+function getNestedVdfSection {
+	VDFPATH="$1"  # i.e. "TopLevel/SecondLevel/ThirdLevel"
+	INDENT="$2"  # indent to start searching from
+	VDF="$3"
+	
+	mapfile -t -d '/' VDFPATHARRAY < <(echo -n "$VDFPATH")
+	VDFPATHARRAYLEN="${#VDFPATHARRAY[*]}"
+	if [ "$VDFPATHARRAYLEN" -eq 0 ]; then
+		writelog "INFO" "${FUNCNAME[0]} - VDFPATHARRY is empty, nothing to do"
+		return
+	fi
+	if [ -z "$INDENT" ]; then
+		INDENT="$(( $( guessVdfIndent "${VDFPATHARRAY[0]}" "$VDF" ) ))"
+	fi
+
+	# Use getVdfSection on each section it finds until we run out of 
+	CURRENTSECTION=""
+	for SECIND in "${!VDFPATHARRAY[@]}"; do
+		# echo "'${VDFPATHARRAY[$SECIND]}'"
+		SECTIONNAME="$( safequoteVdfBlockName "${VDFPATHARRAY[$SECIND]}" )"
+		writelog "INFO" "${FUNCNAME[0]} - Searching for section with name '$SECTIONNAME'"
+		NEXTSECTION="$( getVdfSection "$SECTIONNAME" "" "$INDENT" "$VDF" )"
+		if [ -n "$NEXTSECTION" ]; then
+			CURRENTSECTION="$NEXTSECTION"
+			((INDENT+=1))
+		else
+			writelog "INFO" "${FUNCNAME[0]} - Found no matching section with name '$SECTIONNAME', bailing out"
+			break
+		fi
+	done
+	echo "$CURRENTSECTION"
 }
 
 ## Create entry in given VDF block with matching indentation (Case-INsensitive)
@@ -23031,6 +23086,45 @@ function createVdfEntry {
 
     ## Write out new string to calculated line in VDF file
     sed -i "${INSERTLINE}a\\${NEWBLOCKSTR}" "$VDF"
+}
+
+# Example usage
+function editVdfSectionValue {
+	# Replace newline and tab characters with \n and \t to make sed happy
+	function sanitiseVdfBlockForSed {
+		echo "$1" | awk '{gsub("\t", "\\t"); printf "%s\\n", $0}'
+		# echo "$1" | awk '{printf "%s\\n", $0}'
+	}
+
+	VDFSECTION="$1"  # VDF section text i.e. from getNestedVdfSection
+	VDFPROPERTYNAME="$2"  # i.e. 'OverlayAppEnable'
+	VDFPROPERTYVAL="$3"  # i.e. '1'
+	VDF="$4"
+
+	VDFPROPERTYORGVAL="$( echo "${VDFSECTION}" | grep "${VDFPROPERTYNAME}" )"
+	VDFPROPERTYORGVAL="$( trimWhitespaces "$VDFPROPERTYORGVAL" )"
+
+	VDFPROPERTYNEWVAL="$( createVdfPropertyString "${VDFPROPERTYNAME}" "${VDFPROPERTYVAL}" )"
+
+	UPDATEDVDFSECTION="$( echo "${VDFSECTION}" | sed "s/${VDFPROPERTYORGVAL}/${VDFPROPERTYNEWVAL}/g" )"
+	
+	# SANITISEDVDFSECTION="$( sanitiseVdfBlockForSed "${VDFSECTION}" )"
+	# SANITISEDUPDATEDVDFSECTION="$( sanitiseVdfBlockForSed "${UPDATEDVDFSECTION}" )"
+
+	BLOCKSTART="$( echo "$VDFSECTION" | head -n1 )"
+	BLOCKEND="$( echo "$VDFSECTION" | tail -n1 )"
+
+	echo "'$BLOCKSTART'"
+	echo "'$BLOCKEND'"
+
+	# sed -i "${BLOCKSTART}/,/${BLOCKEND}"
+	# sed -i "|${BLOCKSTART}|,|${BLOCKEND}|c\\${UPDATEDVDFSECTION}" "$VDF"
+
+}
+
+# Return a VDF property string
+function createVdfPropertyString {
+	printf "\"%s\"\t\t\"%s\"" "$1" "$2"
 }
 
 ## Get the internal name of the compatibility tool selected for all titles from the Steam Client Compatibility settings

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -21830,23 +21830,37 @@ function commandline {
 			LOCOUSCO="$( jq '. += { hidden: { id: "hidden", added: [], removed: [] } }' <<< "$LOCOUSCO" )"
 		fi
 
-		LOCOUSCO="$( jq '.hidden.added += [ 3917765712 ] | tojson' <<< "$LOCOUSCO" )"
+		# return
+
+		LOCOUSCO="$( jq '.hidden.added += [ 3917765712 ]' <<< "$LOCOUSCO" )"
 		
-		# if [ "$NOUSCOEXISTS" -eq 1 ]; then
-			# addVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$VDF"
-		# else
-			## TODO editVdfSectionValue doesn't work yet here because of the special characters in the blovk
-			# echo "Editing existing VDF value with '$LOCOUSCO'"
-			# editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$VDF"
-		# fi
+		# prepareJSONVdfProperty "$LOCOUSCO"
+
+		# addVdfSection
+		
+		## These are both close to working now, editVdfSectionValue's awk breaks now
+		# addVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
+		# editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
+		
+		# addVdfSectionValue ""
+
+		if [ "$NOUSCOEXISTS" -eq 1 ]; then
+			echo "Adding new section into VDF"
+			addVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$VDF"
+		else
+			##TODO editVdfSectionValue doesn't work yet here because of the special characters in the blovk
+			echo "Editing existing VDF value with '$LOCOUSCO'"
+			editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$VDF"
+		fi
 
 		## -----
 
 		## Update OverlayAppEnable for given shortcut in localconfig.vdf
-		SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/${DEBUGNOSTAID}" "1" "$DEBUG_LOCOVDF" )"
+		# SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/${DEBUGNOSTAID}" "1" "$DEBUG_LOCOVDF" )"
 
+		## These still work fine
 		# getVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable"
-		editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "0" "$DEBUG_LOCOVDF"
+		# editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "1" "$DEBUG_LOCOVDF"
 	elif [ "$1" == "mo2" ]; then
 		if [ -n "$2" ]; then
 			if [ "$2" == "download" ] || [ "$2" == "d" ]; then
@@ -23117,32 +23131,27 @@ function editVdfSectionValue {
 	VDFPROPERTYNAME="$2"  # i.e. 'OverlayAppEnable'
 	VDFPROPERTYVAL="$3"  # i.e. '1'
 	VDF="$4"
-	
-	# VDFPROPERTYORGVAL="$( getVdfSectionValue "$VDFSECTION" "$VDFPROPERTYNAME" | sed 's/[]\/$*.^[]/\\&/g' )"
-	# VDFPROPERTYORGVAL="$( getVdfSectionValue "$VDFSECTION" "$VDFPROPERTYNAME" )"
-	# VDFPROPERTYNEWVAL="$( createVdfPropertyString "${VDFPROPERTYNAME}" "${VDFPROPERTYVAL}" )"
-	# UPDATEDVDFSECTION="$( echo "${VDFSECTION}" | sed "s@${VDFPROPERTYORGVAL}@${VDFPROPERTYNEWVAL}@g" )"
-	# echo "$UPDATEDVDFSECTION" | awk 'BEGIN{FS=OFS="\""} {$2=gensub(/"/, "\\\\\"", "g", $2); $4=gensub(/"/, "\\\\\"", "g", $4); print}'
-	# echo "$UPDATEDVDFSECTION" | 
 
-	# return
+	VDFPROPERTYORGVAL="$( getVdfSectionValue "$VDFSECTION" "$VDFPROPERTYNAME" | sed 's/[]\/$*.^[]/\\&/g' )"
+	VDFPROPERTYNEWVAL="$( createVdfPropertyString "${VDFPROPERTYNAME}" "${VDFPROPERTYVAL}" )"
+
+	UPDATEDVDFSECTION="$( echo "${VDFSECTION}"| sed "s/${VDFPROPERTYORGVAL}/${VDFPROPERTYNEWVAL}/g" )"
+
 
 	# backupVdfFile "$VDF"
 
-	VDFPROPERTYORGVAL="$( getVdfSectionValue "$VDFSECTION" "$VDFPROPERTYNAME" )"
-	VDFPROPERTYNEWVAL="$( createVdfPropertyString "${VDFPROPERTYNAME}" "${VDFPROPERTYVAL}" )"
-
-	# TODO this falls apart for sections that have nasty special characters that make sed grumpy, like in localconfig.vdf's 'WebStorage' block
-	# We need some way to address this
-	UPDATEDVDFSECTION="$( echo "${VDFSECTION}"| sed "s|${VDFPROPERTYORGVAL}|${VDFPROPERTYNEWVAL}|g" )"
-
-	backupVdfFile "$VDF"
-
-	# Anything prettier would be preferred... But this seems like the best way without resorting to perl
+	# Anything prettier would be preferred (without the tmp file)... But this seems like the best way without resorting to perl
 	TMPVDF="/tmp/updated.vdf"
-	awk -v RS= -v ORS= -v orgsection="${VDFSECTION}" -v updatedsection="${UPDATEDVDFSECTION}" '{gsub(orgsection, updatedsection)}1' "$VDF" > "$TMPVDF"
-	mv "$TMPVDF" "$VDF"
-
+	###
+	## this generally works but breaks when trying to sub in json strings
+	###
+	# awk -v RS= -v ORS= -v orgsection="${VDFSECTION}" -v updatedsection="$UPDATEDVDFSECTION" '{gsub(orgsection, updatedsection)}1' "$VDF" > "$TMPVDF"
+	# mv "$TMPVDF" "$VDF"
+	###
+	# awk -v RS= -v ORS= -v orgsection="${VDFSECTION}" -v updatedsection="$UPDATEDVDFSECTION" '{gsub(orgsection, updatedsection)}1' "$VDF"
+	###
+	VDFSECTIONNAME="$( echo "$UPDATEDVDFSECTION" | head -n1 )"
+	VDFSECTIONEND="$( echo "$UPDATEDVDFSECTION" | tail -n1 )"
 }
 
 ## Add a single value to bottom of a given VDF section
@@ -23160,8 +23169,9 @@ function addVdfSectionValue {
 	VDFPROPERTYINDENT="$( generateVdfIndentString "$(( VDFSECTIONENDINDENTAMT + 1 ))" "" )"
 
 	VDFPROPERTY="${VDFPROPERTYINDENT}$( createVdfPropertyString "$VDFPROPERTYNAME" "$VDFPROPERTYVAL" )"
-
-	sed -i "${VDFSECTIONINSERTLINE}a\\${VDFPROPERTY}" "$VDF"
+	
+	## TODO inserts into wrong line, but it actually writes out the JSON correctly now!!!!
+	sed -i "${VDFSECTIONINSERTLINE}a\\\\${VDFPROPERTY}" "$VDF"
 }
 
 ## Extract value from text-based VDF block
@@ -23181,7 +23191,26 @@ function getVdfSectionValue {
 
 ## Return a VDF property string
 function createVdfPropertyString {
-	printf "%s\t\t%s" "$( safequoteVdfBlockName "$1" )" "$( safequoteVdfBlockName "$2" )"
+	if jq -e '.' 1>/dev/null 2>&1 <<<"$2"; then
+		writelog "INFO" "${FUNCNAME[0]} - Looks like our input string '$2' is JSON -- Creating JSON VDF Property"
+		printf "%s\t\t%s" "$( safequoteVdfBlockName "$1" )" "$( prepareJSONVdfProperty "$2" )"  # Don't use safequote on JSON string
+	else
+		writelog "INFO" "${FUNCNAME[0]} - Generating normal VDF property string for '$1: $2'"
+		printf "%s\t\t%s" "$( safequoteVdfBlockName "$1" )" "$( safequoteVdfBlockName "$2" )"
+	fi
+}
+
+## Format a JSON entry by double-escaping it and removing any surrounding quotes so that it can be written out into the VDF correctly
+## i.e. turn "\"{\\\"foo\\\": \\\"bar\\\"}\"" -> \"{\\\"foo\\\": \\\"bar\\\"}\"
+function prepareJSONVdfProperty {
+	# if ! jq -e '.' 1>/dev/null 2>&1 <<<"$1"; then
+	# 	writelog "SKIP" "${FUNCNAME[0]} - Doesn't look like our input string '$1' is valid JSON -- Skipping"
+	# 	echo "${1}"
+	# fi
+
+	SANITISEDVDFJSON="$( jq '. | tojson | tojson' <<< "$1" )"
+	SANITISEDVDFJSON="${SANITISEDVDFJSON#\"}"  # Remove any plain quote from start
+	echo "${SANITISEDVDFJSON%\"}"  # Remove any plain quote from end
 }
 
 ## Get the internal name of the compatibility tool selected for all titles from the Steam Client Compatibility settings

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231105-6 (updated-vdf-funcs)"
+PROGVERS="v14.0.20231105-2"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231104-1 (updated-vdf-funcs)"
+PROGVERS="v14.0.20231105-2 (updated-vdf-funcs)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -21815,7 +21815,8 @@ function commandline {
 
 		if [ -z "$LOCOUSCO" ]; then
 			echo "No user-collections information defined, creating new one"
-			NOUSCOEXISTS=1
+			# shellcheck disable=SC2034
+			NOUSCOEXISTS=1  # debug var
 			LOCOUSCO="{}"
 		fi
 
@@ -21834,7 +21835,6 @@ function commandline {
 		# 	echo "Adding new section into VDF"
 		# 	addVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
 		# else
-		# 	##TODO editVdfSectionValue doesn't work yet here because of the special characters in the blovk
 		# 	echo "Editing existing VDF value with '$LOCOUSCO'"
 		# 	editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
 		# fi
@@ -21843,9 +21843,8 @@ function commandline {
 
 		## Update OverlayAppEnable for given shortcut in localconfig.vdf
 		SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/${DEBUGNOSTAID}" "1" "$DEBUG_LOCOVDF" )"
-
-		# getVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable"
 		editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "0" "$DEBUG_LOCOVDF"
+		# getVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable"
 	elif [ "$1" == "mo2" ]; then
 		if [ -n "$2" ]; then
 			if [ "$2" == "download" ] || [ "$2" == "d" ]; then
@@ -23119,7 +23118,9 @@ function editVdfSectionValue {
 
 	VDFPROPERTYORGVAL="$( getVdfSectionValue "$VDFSECTION" "$VDFPROPERTYNAME" | sed 's/[]\/$*.^[]/\\&/g' )"
 	VDFPROPERTYNEWVAL="$( createVdfPropertyString "${VDFPROPERTYNAME}" "${VDFPROPERTYVAL}" )"
-
+	
+	# maybe later, PR welcome if you can do this :-)
+	#shellcheck disable=SC2001
 	UPDATEDVDFSECTION="$( echo "${VDFSECTION}"| sed "s/${VDFPROPERTYORGVAL}/${VDFPROPERTYNEWVAL}/g" )"
 
 	backupVdfFile "$VDF"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231103-2"
+PROGVERS="v14.0.20231104-1 (updated-vdf-funcs)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -21801,30 +21801,52 @@ function commandline {
 	elif [ "$1" == "getslrbtn" ]; then  # Internal use only for the Main Menu button
 		fetchGameSLRGui "$2"
 	elif [ "$1" == "debug" ]; then
-		# Why are you looking here? :-)
+		## Why are you looking here? :-)
 
-		# writelog "INFO" "${FUNCNAME[0]} - Stub"
-		LCLCFGVDF="$STUIDPATH/config/localconfig bsak.vdf"
-		# getVdfSection "Apps" "" "" "$LCLCFGVDF"
+		DEBUGNOSTAID="-222353304"
 
-		SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/-222353304" "1" "$LCLCFGVDF" )"
-		# echo "$SHORTCUTLOCALCONFIGVDFSECTION"
-		editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "1" "$LCLCFGVDF"
-
-		# TESTVDF="$HOME/.local/share/Steam/config/config.vdf"
+		## -----
 		
-		# FOUNDSEC="$( getNestedVdfSection "Apps/-222353304" "1" "$LCLCFGVDF" )"
-		# FINDSECPROP="OverlayAppEnable"
-		# ORGSECPROP="$( trimWhitespaces "$( echo "${FOUNDSEC}" | grep "$FINDSECPROP" )" )"
-		# UPDATEDSECPROP="$( printf "\"%s\"\t\t\"%s\"" "$FINDSECPROP" "1" )"
-		# UPDATEDSEC="$( echo "${FOUNDSEC}" | sed "s/${ORGSECPROP}/${UPDATEDSECPROP}/g" )"
+		## Parse JSON information about Non-Steam Game categories
+		NOUSCOEXISTS=0
+		DEBUG_LOCOVDF="$STUIDPATH/config/localconfig bsak.vdf"
 
-		# echo "$ORGSECPROP"
-		# echo "$UPDATEDSECPROP"
-		# echo "$UPDATEDSEC"
-		# getNestedVdfSection "Steam/ShaderCacheManager/App/730" "" "$TESTVDF" 
+		LOCOWESTO="$( getVdfSection "WebStorage" "" "" "$DEBUG_LOCOVDF" )"
+		LOCOUSCO="$( getVdfSectionValue "$LOCOWESTO" "user-collections" "1" )"
 
-		# FOUNDVDFSECTION = editVdfSectionValue "$LCLCFGVDF" "Apps" "-222353304" "1" "OverlayAppEnable" "0"
+		if [ -z "$LOCOUSCO" ]; then
+			echo "No user-collections information defined, creating new one"
+			NOUSCOEXISTS=1
+			LOCOUSCO="{}"
+		fi
+
+		LOCOUSCO="$( jq 'fromjson' <<< "$LOCOUSCO" )"
+
+		## -----
+
+		## Insert Non-Steam Game into user-collection 'hidden' category, creating it if it doesn't exist
+		# if ! jq -e '. | try(.hidden)' <<< "$LOCOUSCO" >/dev/null ; then
+		# 	echo "No hidden games, adding blank hidden category"
+		# 	LOCOUSCO="$( jq '. += { hidden: { id: "hidden", added: [], removed: [] } }' <<< "$LOCOUSCO" )"
+		# fi
+
+		# LOCOUSCO="$( jq '.hidden.added += [ 3917765712 ] | tojson' <<< "$LOCOUSCO" )"
+		
+		# if [ "$NOUSCOEXISTS" -eq 1 ]; then
+		# 	addVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$VDF"
+		# else
+		#   ## TODO editVdfSectionValue doesn't work yet here because of the special characters in the blovk
+		# 	echo "Editing existing VDF value with '$LOCOUSCO'"
+		# 	editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$VDF"
+		# fi
+
+		## -----
+
+		## Update OverlayAppEnable for given shortcut in localconfig.vdf
+		SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/${DEBUGNOSTAID}" "1" "$DEBUG_LOCOVDF" )"
+
+		getVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable"
+		editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "1" "$DEBUG_LOCOVDF"
 	elif [ "$1" == "mo2" ]; then
 		if [ -n "$2" ]; then
 			if [ "$2" == "download" ] || [ "$2" == "d" ]; then
@@ -23088,43 +23110,67 @@ function createVdfEntry {
     sed -i "${INSERTLINE}a\\${NEWBLOCKSTR}" "$VDF"
 }
 
-# Example usage
+## Take in a VDF block and update a property in it, then update the original file with the updated block
+## We can use this to update the compatibility tool for an existing VDF block, or update some Non-Steam Game properties
 function editVdfSectionValue {
-	# Replace newline and tab characters with \n and \t to make sed happy
-	function sanitiseVdfBlockForSed {
-		echo "$1" | awk '{gsub("\t", "\\t"); printf "%s\\n", $0}'
-		# echo "$1" | awk '{printf "%s\\n", $0}'
-	}
-
 	VDFSECTION="$1"  # VDF section text i.e. from getNestedVdfSection
 	VDFPROPERTYNAME="$2"  # i.e. 'OverlayAppEnable'
 	VDFPROPERTYVAL="$3"  # i.e. '1'
 	VDF="$4"
-
-	VDFPROPERTYORGVAL="$( echo "${VDFSECTION}" | grep "${VDFPROPERTYNAME}" )"
-	VDFPROPERTYORGVAL="$( trimWhitespaces "$VDFPROPERTYORGVAL" )"
-
+	
+	VDFPROPERTYORGVAL="$( getVdfSectionValue "$VDFSECTION" "$VDFPROPERTYNAME" )"
 	VDFPROPERTYNEWVAL="$( createVdfPropertyString "${VDFPROPERTYNAME}" "${VDFPROPERTYVAL}" )"
 
-	UPDATEDVDFSECTION="$( echo "${VDFSECTION}" | sed "s/${VDFPROPERTYORGVAL}/${VDFPROPERTYNEWVAL}/g" )"
-	
-	# SANITISEDVDFSECTION="$( sanitiseVdfBlockForSed "${VDFSECTION}" )"
-	# SANITISEDUPDATEDVDFSECTION="$( sanitiseVdfBlockForSed "${UPDATEDVDFSECTION}" )"
+	# TODO this falls apart for sections that have nasty special characters that make sed grumpy, like in localconfig.vdf's 'WebStorage' block
+	# We need some way to address this
+	UPDATEDVDFSECTION="$( echo "${VDFSECTION}"| sed "s|${VDFPROPERTYORGVAL}|${VDFPROPERTYNEWVAL}|g" )"
 
-	BLOCKSTART="$( echo "$VDFSECTION" | head -n1 )"
-	BLOCKEND="$( echo "$VDFSECTION" | tail -n1 )"
+	backupVdfFile "$VDF"
 
-	echo "'$BLOCKSTART'"
-	echo "'$BLOCKEND'"
-
-	# sed -i "${BLOCKSTART}/,/${BLOCKEND}"
-	# sed -i "|${BLOCKSTART}|,|${BLOCKEND}|c\\${UPDATEDVDFSECTION}" "$VDF"
+	# Anything prettier would be preferred... But this seems like the best way without resorting to perl
+	TMPVDF="/tmp/updated.vdf"
+	awk -v RS= -v ORS= -v orgsection="${VDFSECTION}" -v updatedsection="${UPDATEDVDFSECTION}" '{gsub(orgsection, updatedsection)}1' "$VDF" > "$TMPVDF"
+	mv "$TMPVDF" "$VDF"
 
 }
 
-# Return a VDF property string
+## Add a single value to bottom of a given VDF section
+function addVdfSectionValue {
+	VDFSECTION="$1"
+	VDFPROPERTYNAME="$2"
+	VDFPROPERTYVAL="$3"
+	VDF="$4"
+
+	VDFSECTIONEND="$( echo "$VDFSECTION" | tail -n1 )"
+	VDFSECTIONENDLINE="$( echo "$VDFSECTION" | grep -in "$VDFSECTIONEND" | cut -d ':' -f1 )"
+	VDFSECTIONINSERTLINE="$(( VDFSECTIONENDLINE - 1 ))"
+
+	VDFSECTIONENDINDENTAMT="$( echo "$VDFSECTIONEND" | awk '{print gsub(/\t/,"")}' )"
+	VDFPROPERTYINDENT="$( generateVdfIndentString "$(( VDFSECTIONENDINDENTAMT + 1 ))" "" )"
+
+	VDFPROPERTY="${VDFPROPERTYINDENT}$( createVdfPropertyString "$VDFPROPERTYNAME" "$VDFPROPERTYVAL" )"
+
+	sed -i "${VDFSECTIONINSERTLINE}a\\${VDFPROPERTY}" "$VDF"
+}
+
+## Extract value from text-based VDF block
+## ex: "ExampleProperty"		"ex-val"
+function getVdfSectionValue {
+	VDFSECTION="$1"  # VDF section text i.e. from getNestedVdfSection
+	VDFPROPERTYNAME="$2"  # i.e. 'OverlayAppEnable'
+	ONLYVALUE="$3"
+
+	VDFVAL="$( trimWhitespaces "$(echo "${VDFSECTION}" | grep "${VDFPROPERTYNAME}")" )"
+	if [ -n "$ONLYVALUE" ]; then
+		echo "$VDFVAL" | cut -f3
+	else
+		echo "$VDFVAL"
+	fi
+}
+
+## Return a VDF property string
 function createVdfPropertyString {
-	printf "\"%s\"\t\t\"%s\"" "$1" "$2"
+	printf "%s\t\t%s" "$( safequoteVdfBlockName "$1" )" "$( safequoteVdfBlockName "$2" )"
 }
 
 ## Get the internal name of the compatibility tool selected for all titles from the Steam Client Compatibility settings

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -21806,7 +21806,8 @@ function commandline {
 		DEBUGNOSTAID="-222353304"
 
 		## -----
-		## Parse JSON information about Non-Steam Game categories
+		## Mark Non-Steam Game game with given AppID as 'hidden'
+		## Could be extended to add to categories once we can get the category
 		NOUSCOEXISTS=0
 		DEBUG_LOCOVDF="$STUIDPATH/config/localconfig bsak.vdf"
 
@@ -21817,10 +21818,10 @@ function commandline {
 			echo "No user-collections information defined, creating new one"
 			# shellcheck disable=SC2034
 			NOUSCOEXISTS=1  # debug var
-			LOCOUSCO="{}"
+			LOCOUSCO="\"{}\""
 		fi
 
-		LOCOUSCO="$( jq 'fromjson' <<< "$LOCOUSCO" )"
+		LOCOUSCO="$( echo "$LOCOUSCO" | jq 'fromjson' )"
 
 		## -----
 		## Insert Non-Steam Game into user-collection 'hidden' category, creating it if it doesn't exist
@@ -21829,21 +21830,23 @@ function commandline {
 			LOCOUSCO="$( jq '. += { hidden: { id: "hidden", added: [], removed: [] } }' <<< "$LOCOUSCO" )"
 		fi
 
-		LOCOUSCO="$( jq '.hidden.added += [ 4924117535 ]' <<< "$LOCOUSCO" )"
+		LOCOUSCO="$( jq '.hidden.added += [ 9999999999 ]' <<< "$LOCOUSCO" )"
 
-		# if [ "$NOUSCOEXISTS" -eq 1 ]; then
-		# 	echo "Adding new section into VDF"
-		# 	addVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
-		# else
-		# 	echo "Editing existing VDF value with '$LOCOUSCO'"
-		# 	editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
-		# fi
+		if [ "$NOUSCOEXISTS" -eq 1 ]; then
+			echo "Adding new section into VDF"
+			addVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
+		else
+			echo "Editing existing VDF value with '$LOCOUSCO'"
+			editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
+		fi
+
+		# addVdfSectionValue "$LOCOWESTO" "test-val" "testvall" "$DEBUG_LOCOVDF"
 
 		## -----
 
 		## Update OverlayAppEnable for given shortcut in localconfig.vdf
-		SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/${DEBUGNOSTAID}" "1" "$DEBUG_LOCOVDF" )"
-		editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "0" "$DEBUG_LOCOVDF"
+		# SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/${DEBUGNOSTAID}" "1" "$DEBUG_LOCOVDF" )"
+		# editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "0" "$DEBUG_LOCOVDF"
 		# getVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable"
 	elif [ "$1" == "mo2" ]; then
 		if [ -n "$2" ]; then
@@ -23125,11 +23128,7 @@ function editVdfSectionValue {
 
 	backupVdfFile "$VDF"
 
-	## Thanks to StackOverflow for this answer, though as noted, this may break down if the file exceeds 1mb
-	## Probably won't in most cases.
-	VDFCONTENTS="$( cat "$VDF" )"
-	UPDATEDVDFCONTENTS="${VDFCONTENTS//"$VDFSECTION"/"$UPDATEDVDFSECTION"}"
-	printf "%s\n" "$UPDATEDVDFCONTENTS" > "$VDF"
+	substituteVdfSection "$VDFSECTION" "$UPDATEDVDFSECTION" "$VDF"
 }
 
 ## Add a single value to bottom of a given VDF section
@@ -23147,9 +23146,21 @@ function addVdfSectionValue {
 	VDFPROPERTYINDENT="$( generateVdfIndentString "$(( VDFSECTIONENDINDENTAMT + 1 ))" "" )"
 
 	VDFPROPERTY="${VDFPROPERTYINDENT}$( createVdfPropertyString "$VDFPROPERTYNAME" "$VDFPROPERTYVAL" )"
-	
-	## TODO inserts into wrong line, but it actually writes out the JSON correctly now!!!!
-	sed -i "${VDFSECTIONINSERTLINE}a\\\\${VDFPROPERTY}" "$VDF"
+	UPDATEDVDFSECTION="$( echo "$VDFSECTION" | sed "${VDFSECTIONINSERTLINE}a\\${VDFPROPERTY}" )"
+
+	substituteVdfSection "$VDFSECTION" "$UPDATEDVDFSECTION" "$VDF"
+}
+
+## Use parameter expansion to replace old block with new block in VDF file
+## Thanks to StackOverflow for this answer, though was noted this may break down if the file exceeds 1mb -- Should work for us though
+function substituteVdfSection {
+	VDFOLDSECTION="$1"
+	VDFNEWSECTION="$2"
+	VDF="$3"
+
+	VDFCONTENTS="$( cat "$VDF" )"
+	UPDATEDVDFCONTENTS="${VDFCONTENTS//"$VDFOLDSECTION"/"$VDFNEWSECTION"}"
+	printf "%s\n" "$UPDATEDVDFCONTENTS" > "$VDF"
 }
 
 ## Extract value from text-based VDF block

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231105-2 (updated-vdf-funcs)"
+PROGVERS="v14.0.20231105-4 (updated-vdf-funcs)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -21806,7 +21806,6 @@ function commandline {
 		DEBUGNOSTAID="-222353304"
 
 		## -----
-		
 		## Parse JSON information about Non-Steam Game categories
 		NOUSCOEXISTS=0
 		DEBUG_LOCOVDF="$STUIDPATH/config/localconfig bsak.vdf"
@@ -21823,44 +21822,30 @@ function commandline {
 		LOCOUSCO="$( jq 'fromjson' <<< "$LOCOUSCO" )"
 
 		## -----
-
 		## Insert Non-Steam Game into user-collection 'hidden' category, creating it if it doesn't exist
 		if ! jq -e '. | try(.hidden)' <<< "$LOCOUSCO" >/dev/null ; then
 			echo "No hidden games, adding blank hidden category"
 			LOCOUSCO="$( jq '. += { hidden: { id: "hidden", added: [], removed: [] } }' <<< "$LOCOUSCO" )"
 		fi
 
-		# return
+		LOCOUSCO="$( jq '.hidden.added += [ 4924117535 ]' <<< "$LOCOUSCO" )"
 
-		LOCOUSCO="$( jq '.hidden.added += [ 3917765712 ]' <<< "$LOCOUSCO" )"
-		
-		# prepareJSONVdfProperty "$LOCOUSCO"
-
-		# addVdfSection
-		
-		## These are both close to working now, editVdfSectionValue's awk breaks now
-		# addVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
-		# editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
-		
-		# addVdfSectionValue ""
-
-		if [ "$NOUSCOEXISTS" -eq 1 ]; then
-			echo "Adding new section into VDF"
-			addVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$VDF"
-		else
-			##TODO editVdfSectionValue doesn't work yet here because of the special characters in the blovk
-			echo "Editing existing VDF value with '$LOCOUSCO'"
-			editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$VDF"
-		fi
+		# if [ "$NOUSCOEXISTS" -eq 1 ]; then
+		# 	echo "Adding new section into VDF"
+		# 	addVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
+		# else
+		# 	##TODO editVdfSectionValue doesn't work yet here because of the special characters in the blovk
+		# 	echo "Editing existing VDF value with '$LOCOUSCO'"
+		# 	editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
+		# fi
 
 		## -----
 
 		## Update OverlayAppEnable for given shortcut in localconfig.vdf
-		# SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/${DEBUGNOSTAID}" "1" "$DEBUG_LOCOVDF" )"
+		SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/${DEBUGNOSTAID}" "1" "$DEBUG_LOCOVDF" )"
 
-		## These still work fine
 		# getVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable"
-		# editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "1" "$DEBUG_LOCOVDF"
+		editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "0" "$DEBUG_LOCOVDF"
 	elif [ "$1" == "mo2" ]; then
 		if [ -n "$2" ]; then
 			if [ "$2" == "download" ] || [ "$2" == "d" ]; then
@@ -23137,21 +23122,13 @@ function editVdfSectionValue {
 
 	UPDATEDVDFSECTION="$( echo "${VDFSECTION}"| sed "s/${VDFPROPERTYORGVAL}/${VDFPROPERTYNEWVAL}/g" )"
 
+	backupVdfFile "$VDF"
 
-	# backupVdfFile "$VDF"
-
-	# Anything prettier would be preferred (without the tmp file)... But this seems like the best way without resorting to perl
-	TMPVDF="/tmp/updated.vdf"
-	###
-	## this generally works but breaks when trying to sub in json strings
-	###
-	# awk -v RS= -v ORS= -v orgsection="${VDFSECTION}" -v updatedsection="$UPDATEDVDFSECTION" '{gsub(orgsection, updatedsection)}1' "$VDF" > "$TMPVDF"
-	# mv "$TMPVDF" "$VDF"
-	###
-	# awk -v RS= -v ORS= -v orgsection="${VDFSECTION}" -v updatedsection="$UPDATEDVDFSECTION" '{gsub(orgsection, updatedsection)}1' "$VDF"
-	###
-	VDFSECTIONNAME="$( echo "$UPDATEDVDFSECTION" | head -n1 )"
-	VDFSECTIONEND="$( echo "$UPDATEDVDFSECTION" | tail -n1 )"
+	## Thanks to StackOverflow for this answer, though as noted, this may break down if the file exceeds 1mb
+	## Probably won't in most cases.
+	VDFCONTENTS="$( cat "$VDF" )"
+	UPDATEDVDFCONTENTS="${VDFCONTENTS//"$VDFSECTION"/"$UPDATEDVDFSECTION"}"
+	printf "%s\n" "$UPDATEDVDFCONTENTS" > "$VDF"
 }
 
 ## Add a single value to bottom of a given VDF section

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -21805,6 +21805,11 @@ function commandline {
 
 		DEBUGNOSTAID="-222353304"
 
+		# DEBUG_LOCOVDF="$STUIDPATH/config/localconfig bsak.vdf"
+
+		## Get nested VDF section
+		# getNestedVdfSection "Valve/Steam/Apps/7/cloud" "2" "$DEBUG_LOCOVDF"
+
 		## -----
 		## Mark Non-Steam Game game with given AppID as 'hidden'
 		## Could be extended to add to categories once we can get the category
@@ -21823,14 +21828,13 @@ function commandline {
 
 		LOCOUSCO="$( echo "$LOCOUSCO" | jq 'fromjson' )"
 
-		## -----
 		## Insert Non-Steam Game into user-collection 'hidden' category, creating it if it doesn't exist
 		if ! jq -e '. | try(.hidden)' <<< "$LOCOUSCO" >/dev/null ; then
 			echo "No hidden games, adding blank hidden category"
 			LOCOUSCO="$( jq '. += { hidden: { id: "hidden", added: [], removed: [] } }' <<< "$LOCOUSCO" )"
 		fi
 
-		LOCOUSCO="$( jq '.hidden.added += [ 9999999999 ]' <<< "$LOCOUSCO" )"
+		LOCOUSCO="$( jq '.hidden.added += [ 1234567890 ]' <<< "$LOCOUSCO" )"
 
 		if [ "$NOUSCOEXISTS" -eq 1 ]; then
 			echo "Adding new section into VDF"
@@ -21840,13 +21844,13 @@ function commandline {
 			editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$DEBUG_LOCOVDF"
 		fi
 
-		# addVdfSectionValue "$LOCOWESTO" "test-val" "testvall" "$DEBUG_LOCOVDF"
+		addVdfSectionValue "$LOCOWESTO" "test-val" "testvall" "$DEBUG_LOCOVDF"
 
 		## -----
 
 		## Update OverlayAppEnable for given shortcut in localconfig.vdf
-		# SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/${DEBUGNOSTAID}" "1" "$DEBUG_LOCOVDF" )"
-		# editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "0" "$DEBUG_LOCOVDF"
+		SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/${DEBUGNOSTAID}" "1" "$DEBUG_LOCOVDF" )"
+		editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "0" "$DEBUG_LOCOVDF"
 		# getVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable"
 	elif [ "$1" == "mo2" ]; then
 		if [ -n "$2" ]; then
@@ -22967,6 +22971,7 @@ function getVdfSection {
     ENDPATTERN="${2:-\}}"  # Default end pattern to end of block
     INDENT="$3"
     VDF="$4"
+	STOPAFTERFIRSTMATCH="$5"
 
     if [ -z "$INDENT" ]; then
         INDENT="$(( $( guessVdfIndent "$STARTPATTERN" "$VDF" ) ))"
@@ -22978,9 +22983,13 @@ function getVdfSection {
 
 	writelog "INFO" "${FUNCNAME[0]} - Searching for VDF block with name '$STARTPATTERN' in VDF file '$VDF'"
 
-	# TODO: the ^ match was added later on, ensure this doesn't break anything!
-    # TODO the { p; blah } was added later on, ensure this still works!
-	sed -n "/^${INDENTEDSTARTPATTERN}/I,/^${INDENTEDENDPATTERN}/I { p; /${INDENTEDENDPATTERN}/I q }" "$VDF"
+	# This is a very hacky solution to allow 'getNestedVdfSection' to use this function
+	# It needs the start pattern exact match but other functions can't use this
+	if [ -n "$STOPAFTERFIRSTMATCH" ]; then
+		sed -n "/${INDENTEDSTARTPATTERN}/I,/^${INDENTEDENDPATTERN}/I { p; /${INDENTEDENDPATTERN}/I q }" "$VDF"
+	else
+		sed -n "/${INDENTEDSTARTPATTERN}/I,/^${INDENTEDENDPATTERN}/I p" "$VDF"
+	fi
 }
 
 ## Check if a VDF block (block_name) already exists inside a parent block (search_block)
@@ -23009,7 +23018,7 @@ function getNestedVdfSection {
 	VDFPATH="$1"  # i.e. "TopLevel/SecondLevel/ThirdLevel"
 	INDENT="$2"  # indent to start searching from
 	VDF="$3"
-	
+
 	mapfile -t -d '/' VDFPATHARRAY < <(echo -n "$VDFPATH")
 	VDFPATHARRAYLEN="${#VDFPATHARRAY[*]}"
 	if [ "$VDFPATHARRAYLEN" -eq 0 ]; then
@@ -23020,13 +23029,14 @@ function getNestedVdfSection {
 		INDENT="$(( $( guessVdfIndent "${VDFPATHARRAY[0]}" "$VDF" ) ))"
 	fi
 
-	# Use getVdfSection on each section it finds until we run out of 
+	# Use getVdfSection on each section it finds until we run out of
 	CURRENTSECTION=""
 	for SECIND in "${!VDFPATHARRAY[@]}"; do
 		# echo "'${VDFPATHARRAY[$SECIND]}'"
 		SECTIONNAME="$( safequoteVdfBlockName "${VDFPATHARRAY[$SECIND]}" )"
 		writelog "INFO" "${FUNCNAME[0]} - Searching for section with name '$SECTIONNAME'"
-		NEXTSECTION="$( getVdfSection "$SECTIONNAME" "" "$INDENT" "$VDF" )"
+		NEXTSECTION="$( getVdfSection "$SECTIONNAME" "" "$INDENT" "$VDF" "X" )"
+		writelog "INFO" "${FUNCNAME[0]} - NEXTSECTION is '$NEXTSECTION'"
 		if [ -n "$NEXTSECTION" ]; then
 			CURRENTSECTION="$NEXTSECTION"
 			((INDENT+=1))
@@ -23121,7 +23131,7 @@ function editVdfSectionValue {
 
 	VDFPROPERTYORGVAL="$( getVdfSectionValue "$VDFSECTION" "$VDFPROPERTYNAME" | sed 's/[]\/$*.^[]/\\&/g' )"
 	VDFPROPERTYNEWVAL="$( createVdfPropertyString "${VDFPROPERTYNAME}" "${VDFPROPERTYVAL}" )"
-	
+
 	# maybe later, PR welcome if you can do this :-)
 	#shellcheck disable=SC2001
 	UPDATEDVDFSECTION="$( echo "${VDFSECTION}"| sed "s/${VDFPROPERTYORGVAL}/${VDFPROPERTYNEWVAL}/g" )"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231105-4 (updated-vdf-funcs)"
+PROGVERS="v14.0.20231105-5 (updated-vdf-funcs)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -23202,11 +23202,6 @@ function createVdfPropertyString {
 ## Format a JSON entry by double-escaping it and removing any surrounding quotes so that it can be written out into the VDF correctly
 ## i.e. turn "\"{\\\"foo\\\": \\\"bar\\\"}\"" -> \"{\\\"foo\\\": \\\"bar\\\"}\"
 function prepareJSONVdfProperty {
-	# if ! jq -e '.' 1>/dev/null 2>&1 <<<"$1"; then
-	# 	writelog "SKIP" "${FUNCNAME[0]} - Doesn't look like our input string '$1' is valid JSON -- Skipping"
-	# 	echo "${1}"
-	# fi
-
 	SANITISEDVDFJSON="$( jq '. | tojson | tojson' <<< "$1" )"
 	SANITISEDVDFJSON="${SANITISEDVDFJSON#\"}"  # Remove any plain quote from start
 	echo "${SANITISEDVDFJSON%\"}"  # Remove any plain quote from end

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -21825,19 +21825,19 @@ function commandline {
 		## -----
 
 		## Insert Non-Steam Game into user-collection 'hidden' category, creating it if it doesn't exist
-		# if ! jq -e '. | try(.hidden)' <<< "$LOCOUSCO" >/dev/null ; then
-		# 	echo "No hidden games, adding blank hidden category"
-		# 	LOCOUSCO="$( jq '. += { hidden: { id: "hidden", added: [], removed: [] } }' <<< "$LOCOUSCO" )"
-		# fi
+		if ! jq -e '. | try(.hidden)' <<< "$LOCOUSCO" >/dev/null ; then
+			echo "No hidden games, adding blank hidden category"
+			LOCOUSCO="$( jq '. += { hidden: { id: "hidden", added: [], removed: [] } }' <<< "$LOCOUSCO" )"
+		fi
 
-		# LOCOUSCO="$( jq '.hidden.added += [ 3917765712 ] | tojson' <<< "$LOCOUSCO" )"
+		LOCOUSCO="$( jq '.hidden.added += [ 3917765712 ] | tojson' <<< "$LOCOUSCO" )"
 		
 		# if [ "$NOUSCOEXISTS" -eq 1 ]; then
-		# 	addVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$VDF"
+			# addVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$VDF"
 		# else
-		#   ## TODO editVdfSectionValue doesn't work yet here because of the special characters in the blovk
-		# 	echo "Editing existing VDF value with '$LOCOUSCO'"
-		# 	editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$VDF"
+			## TODO editVdfSectionValue doesn't work yet here because of the special characters in the blovk
+			# echo "Editing existing VDF value with '$LOCOUSCO'"
+			# editVdfSectionValue "$LOCOWESTO" "user-collections" "$LOCOUSCO" "$VDF"
 		# fi
 
 		## -----
@@ -21845,8 +21845,8 @@ function commandline {
 		## Update OverlayAppEnable for given shortcut in localconfig.vdf
 		SHORTCUTLOCALCONFIGVDFSECTION="$( getNestedVdfSection "Apps/${DEBUGNOSTAID}" "1" "$DEBUG_LOCOVDF" )"
 
-		getVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable"
-		editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "1" "$DEBUG_LOCOVDF"
+		# getVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable"
+		editVdfSectionValue "$SHORTCUTLOCALCONFIGVDFSECTION" "OverlayAppEnable" "0" "$DEBUG_LOCOVDF"
 	elif [ "$1" == "mo2" ]; then
 		if [ -n "$2" ]; then
 			if [ "$2" == "download" ] || [ "$2" == "d" ]; then
@@ -23118,6 +23118,17 @@ function editVdfSectionValue {
 	VDFPROPERTYVAL="$3"  # i.e. '1'
 	VDF="$4"
 	
+	# VDFPROPERTYORGVAL="$( getVdfSectionValue "$VDFSECTION" "$VDFPROPERTYNAME" | sed 's/[]\/$*.^[]/\\&/g' )"
+	# VDFPROPERTYORGVAL="$( getVdfSectionValue "$VDFSECTION" "$VDFPROPERTYNAME" )"
+	# VDFPROPERTYNEWVAL="$( createVdfPropertyString "${VDFPROPERTYNAME}" "${VDFPROPERTYVAL}" )"
+	# UPDATEDVDFSECTION="$( echo "${VDFSECTION}" | sed "s@${VDFPROPERTYORGVAL}@${VDFPROPERTYNEWVAL}@g" )"
+	# echo "$UPDATEDVDFSECTION" | awk 'BEGIN{FS=OFS="\""} {$2=gensub(/"/, "\\\\\"", "g", $2); $4=gensub(/"/, "\\\\\"", "g", $4); print}'
+	# echo "$UPDATEDVDFSECTION" | 
+
+	# return
+
+	# backupVdfFile "$VDF"
+
 	VDFPROPERTYORGVAL="$( getVdfSectionValue "$VDFSECTION" "$VDFPROPERTYNAME" )"
 	VDFPROPERTYNEWVAL="$( createVdfPropertyString "${VDFPROPERTYNAME}" "${VDFPROPERTYVAL}" )"
 


### PR DESCRIPTION
This PR adds various new VDF parsing functions that we can use when manipulating VDF block values.

- `getNestedVdfSection` - Allows for searching for the first match of a given VDF section path, including an optional indentation level to start searching from.
    - Usage: `getNestedVdfSection "/vdf/section/path" "startIndentation" "vdf_file"`
    - Example: `getNestedVdfSection "Valve/Steam/ShaderCacheManager/App" "1" "$HOME/.local/share/Steam/config/config.vdf"`
- `getVdfSectionValue` - Return the value of a VDF property within a given block.
    - Usage: `getVdfSectionValue "sectionString" "propertyName"`
    - Example: `getVdfSectionValue "$( getNestedVdfSection "App/1234567890" "OverlayAppEnable" ""$HOME/.local/share/Steam/userdata/xxx/config/localconfig.vdf" )" "OverlayAppEnable"`
- `createVdfPropertyString` - VDF properties follow a fixed format, this helper function can generate a VDF property string preparing it for entry in a VDF block.
    - Usage: `createVdfPropertyString "propertyName" "propertyValue"`
    - Example: `createVdfPropertyString "DisableLaunchInVR" "0"`
- `prepareJSONVdfProperty` - We need to escape JSON strings before entering them into a VDF file, in order to preserve the escape sequences that the VDF file expects. This function does the heavy lifting and even manages removing start and end quotes when needed.
    - Usage: `prepareJSONVdfProperty "stringifiedJSON"`
    - Example: `prepareJSONVdfProperty "{"hello": "world", "foo": { "bar": ["foo", "bar"], "foobar": true, "barfoo": false }}"`
- `substituteVdfSection` - Helper to replace an exact VDF section in a given VDF file with a manipulated one.
    - Usage: `substituteVdfSection "oldSection" "newSection" "vdf_file"`
    - Example: `substituteVdfSection "$( getNestedVdfSection "App/1234567890" )" ""\1234567890\"\n{\n\t\t\"foo\"\t\t\"bar\"\n}" "vdf_path"` -- Indentation doesn't match here, but just an example (mainly meant for use by `addVdfSectionValue` and `editVdfSectionValue` below)
- `addVdfSectionValue` - Add a new value to a VDF section. It will also auto-detect when we're dealing with a JSON string
    - Usage: `addVdfSectionValue "vdfSectionString" "newPropName" "newPropVal" "vdf_path"`
    - Example: `addVdfSectionValue "$( getNestedVdfSection "App/1234567890" )" "MyProp" "0" "vdf_path"`
- `editVdfSectionValue` - Edit an existing property's value within a given VDF section. Also auto-detects and handles JSON strings elegently
    - Usage: `editVdfSectionValue "vdfSectionString" "updatePropName" "updatePropVal "vdf_path"`
    - Example: `editVdfSectionValue "$( getNestedVdfSection "App/1234567890" )" "OverlayAppEnable" "1" "vdf_path"`

<hr>

There are also some (temporary) examples to proof out how we can use these functions in some upcoming work, such as for setting/updating a Non-Steam Game App entry in `localconfig.vdf` to toggle whether the Steam Overlay should be enabled for a given app. There is also an example of updating/creating the `user-collections` value to mark a Non-Steam Game as hidden. In future, we should be able to use this to add a Non-Steam Game to a collection, once we are able to reliably get the list of collection IDs by name to write into this JSON block.

<hr>

These functions are not really used yet outside of the debug scenarios in the code, but are a prerequisite to some upcoming work. They will allow us to do the following:
- Update existing `CompatToolMapping` entry when adding Non-Steam Games
- Fix setting Non-Steam Games as Hidden (currently set in VDF but does nothing, it is handled in `user-collections` in `localconfig.vdf`
- Fix setting Non-Steam Games AllowOverlay option (currently set in VDF but does nothing, it is handled in `"Apps"/appid` section of `localconfig.vdf`)
- Eventually, fix Non-Steam Game categories, once we can get their LevelDB ID (see #949 for background on where and how they're stored). These functions will allow us to insert into `user-collections` once we have the collection ID though.

<hr>

TODO:
- [x] Code cleanup
- [x] Version bump