### PR TITLE
Commandline: Add support for Non-Steam Games to getCompatData

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231108-4 (nonsteam-getcompatdata-fix)"
+PROGVERS="v14.0.20231108-4"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231108-3"
+PROGVERS="v14.0.20231108-4 (nonsteam-getcompatdata-fix)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -7849,6 +7849,8 @@ function getGameExe {
 }
 
 function getCompatData {
+	SEARCHSTEAMSHORTCUTS="${2:-0}"  # Default to not searching Steam shortcuts
+
 	if [ -z "$1" ]; then
 		echo "A Game ID or Game Title is required as argument"
 	else
@@ -7897,6 +7899,25 @@ function getCompatData {
 					if [ -d "$COMPATDATADIR" ]; then
 						COMPATGAMESTR="$COMPATGAMENAME ($COMPATGAMEAID) -> $COMPATDATADIR"
 					fi
+				fi
+
+				# Check Steam Shortcuts for games never launched with STL
+				if [ ! -d "$SEARCHGAMEDIR" ] && [ "$SEARCHSTEAMSHORTCUTS" -eq 1 ] && haveAnySteamShortcuts ; then
+					while read -r SCVDFE; do
+						SCVDFEAID="$( parseSteamShortcutEntryAppID "$SCVDFE" )"
+						SCVDFENAME="$( parseSteamShortcutEntryAppName "$SCVDFE" )"
+
+						## If we have a match, build a hardcoded compatdata pointing at the Steam Root compatdata dir and if it exists, return that
+						## Seems like this is always where Steam generates compatdata for Non-Steam Games
+						## may instead be primary drive which defaults to Steam Root, but for now looks like Steam Root is the main place, so should work most of the time
+						if [ "$SCVDFEAID" -eq "$1" ] 2>/dev/null || [[ ${SCVDFENAME,,} == *"${1,,}"* ]]; then
+							SCVDFECODA="$SROOT/$SA/$CODA/${SCVDFEAID}"
+							if [ -d "$SCVDFECODA" ]; then
+								COMPATGAMESTR="$SCVDFENAME ($SCVDFEAID) -> $SCVDFECODA"
+							fi
+							break
+						fi
+					done <<< "$( getSteamShortcutHex )"
 				fi
 
 				echo "${COMPATGAMESTR:-$NOTFOUNDSTR}"
@@ -22020,7 +22041,7 @@ function commandline {
 	elif [ "$1" == "gettitle" ] || [ "$1" == "gt" ]; then
 		getTitleFromID "$2" "1"
 	elif [ "$1" == "getcompatdata" ] || [ "$1" == "gc" ]; then
-		getCompatData "$2"
+		getCompatData "$2" "1"
 	elif [ "$1" == "getgamedir" ] || [ "$1" == "gg" ]; then
 		if [ "$3" == "only" ]; then
 			getGameDir "$2" "X"


### PR DESCRIPTION
Another piece for #960.

This PR adds support for Non-Steam Games with `getCompatData`. We already have partial support, if a game is launched with SteamTinkerLaunch, because we can get the game name and EXE already with existing functions, and we can get the compatdata with the symlink SteamTinkerLaunch creates.

However, for games not launched with SteamTinkerLaunch before, it fails. To resolve this, we can simply generate a default compatdata path. In testing, it looks like Non-Steam Games always have a compatdata created in the Steam Root library folder (i.e. `~/.local/share/Steam/steamapps/compatdata/<appid>`). Since we can parse `shortcuts.vdf` now it's very easy to loop through all shortcuts and simply generate a path like above. As a safety, we check to make sure this actually exists before returning it. We build the return string using the information from `shortcuts.vdf` even if we have information from earlier in the function, in case the shortcut name has changed or something, just to make sure we have the most up-to-date information.

There is a possibility that the compatdata location assumption is *not* correct, and that Steam actually creates the compatdata at the "default" library folder. By default Steam does set this to the Steam Root library folder, but it is possible that if Steam uses some other location that this Steam root path will not have the compatdata, and so this command will not find the compatdata. I think that's a big "if" though, so for now, this works :-)

<hr>

After a shellcheck and some more testing, I think this is good to merge.