### PR TITLE
Commandline: Add support for Non-Steam Games to getGameDir

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231108-5 (nonsteam-getgamedir-fix)"
+PROGVERS="v14.0.20231109-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -8000,7 +8000,7 @@ function getGameDir {
 					APPMAGN="${SCVDFENAME}"
 					APPMAAID="${SCVDFEAID}"
 					GAMINSTDIR="$( dirname "${SCVDFEEXE}" )"  # Could still fail if EXE dir no longer exists, but edge case
-					
+
 					# TODO make this a function later, we use this a lot
 					GAMINSTDIR="${GAMINSTDIR#\"}"
 					GAMINSTDIR="${GAMINSTDIR%\"}"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20231108-4"
+PROGVERS="v14.0.20231108-5 (nonsteam-getgamedir-fix)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -7948,6 +7948,8 @@ function getValueFromAppManifest {
 # Returns game install directory in the format "Game (AppID) -> /path/to/gamefolder"
 function getGameDir {
 	ONLYPATH="$2"
+	SEARCHSTEAMSHORTCUTS="${3:-0}"  # Default to not searching Steam shortcuts
+	FOUNDINSTEAMSHORTCUTS=0
 
 	if [ -z "$1" ]; then
 		echo "A Game ID or Game Title is required as argument"
@@ -7965,9 +7967,13 @@ function getGameDir {
 
 			SEARCHMANIFEST="$( listAppManifests | grep -m1 "appmanifest_${SEARCHAID}.acf" )"
 			if [ -z "$SEARCHMANIFEST" ]; then
-				writelog "ERROR" "${FUNCNAME[0]} - Could not find game directory for '$1' - Maybe it is not installed"
-				echo "Could not find game directory for '$1'"
-				return 1
+				if [ "$SEARCHSTEAMSHORTCUTS" -eq 0 ]; then
+					writelog "ERROR" "${FUNCNAME[0]} - Could not find game directory for '$1' - Maybe it is not installed"
+					echo "Could not find game directory for '$1'"
+					return 1
+				else
+					writelog "WARN" "${FUNCNAME[0]} - Could not find game directory for '$1' - Will search on Steam Shortcuts next"
+				fi
 			else
 				writelog "INFO" "${FUNCNAME[0]} - Found matching App Manifest '$SEARCHMANIFEST'"
 			fi
@@ -7975,13 +7981,42 @@ function getGameDir {
 			writelog "INFO" "${FUNCNAME[0]} - Found matching App Manifest file for presumed entered AppID '$1' - Manifest file is '$SEARCHMANIFEST'"
 		fi
 
-		APPMAINSTDIR="$( getValueFromAppManifest "installdir" "$SEARCHMANIFEST" )"
+		APPMAINSTDIR="$( getValueFromAppManifest "installdir" "$SEARCHMANIFEST" 2>/dev/null )"
 		APPMALIBFLDR="$( dirname "$SEARCHMANIFEST" )"
 		GAMINSTDIR="$APPMALIBFLDR/common/$APPMAINSTDIR"
 		MUSINSTDIR="$APPMALIBFLDR/music/$APPMAINSTDIR"  # Fixes a not found error for installed soundtracks
+
+		# If still not found, optionally search Steam shortcuts
+		if [ ! -d "$GAMINSTDIR" ] && [ "$SEARCHSTEAMSHORTCUTS" -eq 1 ] && haveAnySteamShortcuts ; then
+			while read -r SCVDFE; do
+				SCVDFEAID="$( parseSteamShortcutEntryAppID "$SCVDFE" )"
+				SCVDFENAME="$( parseSteamShortcutEntryAppName "$SCVDFE" )"
+				SCVDFEEXE="$( parseSteamShortcutEntryExe "$SCVDFE" )"
+
+				## If we have a match, build a hardcoded compatdata pointing at the Steam Root compatdata dir and if it exists, return that
+				## Seems like this is always where Steam generates compatdata for Non-Steam Games
+				## may instead be primary drive which defaults to Steam Root, but for now looks like Steam Root is the main place, so should work most of the time
+				if [ "$SCVDFEAID" -eq "$1" ] 2>/dev/null || [[ ${SCVDFENAME,,} == *"${1,,}"* ]]; then
+					APPMAGN="${SCVDFENAME}"
+					APPMAAID="${SCVDFEAID}"
+					GAMINSTDIR="$( dirname "${SCVDFEEXE}" )"  # Could still fail if EXE dir no longer exists, but edge case
+					
+					# TODO make this a function later, we use this a lot
+					GAMINSTDIR="${GAMINSTDIR#\"}"
+					GAMINSTDIR="${GAMINSTDIR%\"}"
+
+					FOUNDINSTEAMSHORTCUTS=1
+					break
+				fi
+			done <<< "$( getSteamShortcutHex )"
+		fi
+
 		if [ -d "$GAMINSTDIR" ] || [ -d "$MUSINSTDIR" ]; then
-			APPMAGN="$( getValueFromAppManifest "name" "$SEARCHMANIFEST" )"
-			APPMAAID="$( getValueFromAppManifest "appid" "$SEARCHMANIFEST" )"
+			# Don't fetch these if we found and set the information already from a Steam shortcuts
+			if [ "$FOUNDINSTEAMSHORTCUTS" -eq 0 ]; then
+				APPMAGN="$( getValueFromAppManifest "name" "$SEARCHMANIFEST" )"
+				APPMAAID="$( getValueFromAppManifest "appid" "$SEARCHMANIFEST" )"
+			fi
 
 			if [ -z "$ONLYPATH" ]; then
 				printf "%s (%s) -> %s\n" "$APPMAGN" "$APPMAAID" "$GAMINSTDIR"
@@ -22044,9 +22079,9 @@ function commandline {
 		getCompatData "$2" "1"
 	elif [ "$1" == "getgamedir" ] || [ "$1" == "gg" ]; then
 		if [ "$3" == "only" ]; then
-			getGameDir "$2" "X"
+			getGameDir "$2" "X" "1"
 		else
-			getGameDir "$2"
+			getGameDir "$2" "" "1"
 		fi
 	elif [ "$1" == "help" ] || [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
 		howto


### PR DESCRIPTION
Yet another bit of work for #960.

This PR adds support for getting a Non-Steam Game's game folder. We do this by parsing the Exe out of the `shortcuts.vdf` file and using the `dirname` of this as the EXE name. It was a little tricky integrating this into the existing `getGameDir` function, but I did it pretty cleanly, ignoring certain values or returning early if we still have to search on Non-Steam Games.

Initially in #960 I thought about parsing out the `StartDir`, but I think using the Exe base dir makes more sense. They're usually the same, and if they aren't, the user modified that and can check it from Steam. I don't see a case where a user would need to know the `StartDir` though, but I can imagine cases where they want to know where their Non-Steam Game was installed quickly from a command.

This function is also compatible with the `only` option that can be passed to this function. 

In testing this works, but we need to make extra sure this doesn't break anything. After that though, a shellcheck and version bump will make this ready for merging.

<hr>

This PR should complete the function integration work for Non-Steam Games, meaning the remaining work for #970 involves modifying `localconfig.vdf` using the functions added in #967, and the integration into the `list` command.

These functions were integrated first because `list` may make use of these, so I wanted to integrate them first. They're also just useful to have integrated!