### PR TITLE
Steam Linux Runtime: Fix Native Game Crash When SLR 1.0 is Missing

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -20795,6 +20795,7 @@ function getRequireToolAppidPath {
 
 # Function to get SLR to append to game/program launch
 # Primarily used to set SLRCMD so it can be appended, but also sets the reaper command
+# TODO: refactor to use early returns and less indentation where possible
 function setSLRReap {
 	# This function has gotten a bit messy with all the override options, but these are used to allow setSLRReap to be re-used outside of regular game launches such as for Vortex.
 
@@ -20897,9 +20898,15 @@ function setSLRReap {
 				if [ -n "${NATIVE_SLRCMD[*]}" ]; then
 					writelog "INFO" "${FUNCNAME[0]} - Building Steam Linux Runtime command for native game"
 					SLRCMD=("${PROTON_SLRCMD[@]}" "${NATIVE_SLRCMD[@]}")  # Not really "Proton" for native games, but naming is hard
-				else
+				elif [ -n "${PROTON_SLRCMD[*]}" ]; then
 					writelog "INFO" "${FUNCNAME[0]} - Building Steam Linux Runtime command for Proton game"
 					SLRCMD=("${PROTON_SLRCMD[@]}")
+				else
+					if [ "${REQUIRED_APPID}" = "${SLRAID}" ]; then  # Assume native when REQUIRED_APPID is set to the native Linux SLRAID
+						writelog "WARN" "${FUNCNAME[0]} - No native linux Steam Linux Runtime found, game will not use Steam Linux Runtime"
+					else  # If not native, can only be Proton
+						writelog "WARN" "${FUNCNAME[0]} - No Proton Steam Linux Runtime found, game will not use Steam Linux Runtime"
+					fi
 				fi
 			fi
 		fi

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230105-2 (fix-native-slr-missing)"
+PROGVERS="v14.0.20230105-2"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20230105-1"
+PROGVERS="v14.0.20230105-2 (fix-native-slr-missing)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"


### PR DESCRIPTION
Fixes #998.

## Overview
This PR fixes native Linux games crashing when the SLR 1.0 is not installed. This is because when it is not installed, in `setSLRReap`,  `NATIVE_SLRCMD` is empty. In such an instance we correctly assume the SLR is not installed, but *incorrectly* fall back to trying to generate `PROTON_SLRCMD`. However for native games, if we don't have the SLR installed, this is wrong. This means we're generating a bad SLRCMD and so STL will then think it is installed and try to insert it into the launch command for games (blank string values in arrays create bad strings, i.e. something like `"/usr/bin/mangohud" "" "/path/to/game"` will cause a crash, the blank string is invalid, but this is the value of the SLRCMD, since it's inserting the blank string for `PROTON_SLRCMD`, which should only happen if PROTON_SLRCMD is actually set. This results in generating a bad launch command (probably inserts a bad `SLRCMD` when generating the launch command somewhere).

For some reason, the code assumed when NATIVESLR_CMD was not set, it was okay to fall back to using the Proton SLR CMD. this is wrong and we should only do this fallback as well if PROTON_SLRCMD is defined (which only happens when the SLR is found!).

To fix this issue, we add an else block to only fall back to PROTON_SLRCMD if it is actually set. This means when the SLR is not found we don't incorrectly generate an SLRCMD.

This does not affect anything when the SLR is disabled, as we simply skip all of this code. The only time `NATIVE_SLRCMD` could be empty for native games is if we don't have SLR 1.0 installed.

## Background
Native games will crash if 'Steam Linux Runtime 1.0 (Scout)' is not installed, this is because SteamTinkerLaunch incorrectly tries to fall back to generating a wrong command and does not properly return the empty SLRCMD variable. This leads to generating the launch command incorrectly, as STL thinks the SLR is installed and is valid.

To fix this, we do an extra check to ensure the Proton SLR command is only generated when we're using the Proton SLR, and which avoids us falling back on the Proton SLR codepath when NATIVE_SLRCMD is not set. It is incorrect to assume that because the NATIVE_SLRCMD is not set that we're using Proton, we should only fall back to using PROTON_SLRCMD if we actually set the PROTON_SLRCMD earlier.

## Remaining Work
This PR needs a little bit more testing before I am confident that it works. I tested with Half-Life (native) and PowerWash Simulator (GE-Proton8-25), with and without the Steam Linux Runtime enabled, and with some hacky code to force the SLR as not found (`if [ -d "$SLR_PATH" ] && [ 1 -eq 2]; then`) and it appears to work fine. The SLR is correctly used and the launch command looks valid when the SLR is on and off, and forcing the SLR to be not found for both native and Proton games does not cause any crashes and will also correctly not use the SLR when it it is (presumed) not found. The launch command looks correct in all of these tests, and the logging including the new logging is appearing as expected too.

TODO:
- [ ] More testing
- [ ] Version bump