### PR TITLE
Commandline: Refactor getTitleFromID to be more reliable with Non-Steam Games

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7834,40 +7834,51 @@ function getIDFromTitle {
 
 function getTitleFromID {
 	SEARCHSTEAMSHORTCUTS="${2:-0}"  # Default to not searching Steam shortcuts
+	FOUNDGAMETITLE=""
 
 	if [ -z "$1" ]; then
 		echo "A Game ID is required as argument"
-	else
-		if [ -f "$GEMETA/${1}.conf" ]; then
-			if grep -q "^NAME" "$GEMETA/${1}.conf"; then
-				grep "^NAME" "$GEMETA/${1}.conf" | cut -d '"' -f2
-			else
-				getAppInfoData "$1" "name"
-			fi
+		return 1;
+	fi
+
+	# Search meta file if we have one for Game Title
+	if [ -f "$GEMETA/${1}.conf" ]; then
+		if grep -q "^NAME" "$GEMETA/${1}.conf"; then
+			FOUNDGAMETITLE="$( grep "^NAME" "$GEMETA/${1}.conf" | cut -d '"' -f2 )"
 		else
-			# Try to get AppManifest based on passed ID if we don't have a data file
-			GAMEMANIFEST="$( listAppManifests | grep -m1 "appmanifest_${1}.acf" )"
-
-			if [ -n "$GAMEMANIFEST" ]; then
-				getValueFromAppManifest "name" "$GAMEMANIFEST"
-			elif [ "$SEARCHSTEAMSHORTCUTS" -eq "1" ] && haveAnySteamShortcuts ; then
-				# Steam shortcuts
-				while read -r SCVDFE; do
-					SVDFENAME="$( parseSteamShortcutEntryAppName "$SCVDFE" )"
-					SVDFEAID="$( parseSteamShortcutEntryAppID "$SCVDFE" )"
-
-					if [ "$SVDFEAID" -eq "$1" ]; then
-						echo "$SVDFENAME"
-						break
-					fi
-				done <<< "$( getSteamShortcutHex )"
-			else
-				echo "No Title found for '$1'"
-
-				return 1
-			fi
+			FOUNDGAMETITLE="$( getAppInfoData "$1" "name" )"
 		fi
 	fi
+
+	# Try to get title from Steam appmanifest if we didn't find Game Title in meta file
+	if [ -z "$FOUNDGAMETITLE" ]; then
+		GAMEMANIFEST="$( listAppManifests | grep -m1 "appmanifest_${1}.acf" )"
+
+		if [ -n "$GAMEMANIFEST" ]; then
+			FOUNDGAMETITLE="$( getValueFromAppManifest "name" "$GAMEMANIFEST" )"
+		fi
+	fi
+
+	# If we still haven't found the Game Title in the game meta file or appmanifest, check Steam Shortcuts if the option is enabled and if we have any
+	if [ -z "$FOUNDGAMETITLE" ] && [ "$SEARCHSTEAMSHORTCUTS" -eq "1" ] && haveAnySteamShortcuts ; then
+		while read -r SCVDFE; do
+			SVDFENAME="$( parseSteamShortcutEntryAppName "$SCVDFE" )"
+			SVDFEAID="$( parseSteamShortcutEntryAppID "$SCVDFE" )"
+
+			if [ "$SVDFEAID" -eq "$1" ]; then
+				FOUNDGAMETITLE="$SVDFENAME"
+				break
+			fi
+		done <<< "$( getSteamShortcutHex )"
+	fi
+
+	# If we didn't find the name in the STL meta file, Steam appmanifest, or shortcuts.vdf, give up
+	if [ -z "$FOUNDGAMETITLE" ]; then
+		echo "No Title found for '$1'"
+		return 1
+	fi
+
+	echo "$FOUNDGAMETITLE"
 }
 
 # Relies on game executable existing in STL meta file (i.e. any game launched before with STL)
@@ -25389,7 +25400,7 @@ function steamdeckBeforeGame {
 			writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Game Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"
 			writelog "INFO" "${FUNCNAME[0]} - Force-enabling DXVK_HDR=1 for Steam Deck Game Mode, allows HDR support for Steam Deck OLED and HDR displays attached to Steam Deck"
 
-			# Override config value without updating the stored value itself, to preserve compatibility with Desktop Mode 
+			# Override config value without updating the stored value itself, to preserve compatibility with Desktop Mode
 			export DXVK_HDR=1
 		else
 			writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Desktop Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240112-2"
+PROGVERS="v14.0.20240112-3"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"


### PR DESCRIPTION
## Overview
I noticed an issue with a Non-Steam Game that I have launched with SteamTinkerLaunch before not returning the game title correctly with `getTitleFromID`. I found this while working on #1007, where using it for Non-Steam Games sometimes had a blank name. I narrowed the cause down to the game having an STL meta file that was missing the title (since we don't have the title for Non-Steam Games). If we didn't find the title in the meta file, we weren't continuing to search, which was causing the issue since Non-Steam Games have a meta file but not a title, and so we were never continuing beyond this to search on `shortcuts.vdf`.

This PR refactors `getTitleFromID` significantly, making it less nested and now checking on SteamTinkerLaunch meta file, then falling back to appmanifest, and then falling back to `shortcuts.vdf` to try and find the corresponding Title for a given AppID. Previously, we were checking only one of these. This meant if there was a meta file without a title (which is potentially the case for Non-Steam Games), we would not find the App Name.

## Implementation
The function has been refactored so that we use a variable to track the game title. We set this each time we search for the game title. If it is blank, we assume we can move onto the next search method. It works like this:
- By default, `FOUNDGAMETITLE` is blank.
- If we have a SteamTinkerLaunch metadata file, search for the game title in it and store the result in `FOUNDGAMETITLE`.
- If `FOUNDGAMETITLE` is still blank after this, search the Steam AppManifest file for a `name` key and store the result in `FOUNDGAMETITLE` again.
- If `FOUNDGAMETITLE` is once again still blank, and if we have Steam Shortcuts that we have enabled searching on (`SEARCHSTEAMSHORTCUTS`), then search `shortcuts.vdf` for the Game Title. If we get a match, store the Game Title for this shortcut entry in `FOUNDGAMETITLE`
    - If there are no shortcuts OR if searching on Steam Shortcuts is disabled, this step is skipped
- If after all of this, `FOUNDGAMETITLE` is still empty, display that no game is found.
- Otherwise, echo out the game title at the end of the function.

To me, this is much more logical and also easier to read.

<hr>

This PR needs a bit more testing before merging. We need to test that game names are still displayed correctly on the Game Menu, and ensure that any parts of the code that use `getTitleFromID` still function correctly. I tested quickly with `getExe` and it still works correctly.