### PR TITLE
ModOrganizer 2: Prevent MO2MODE from being 'none', only checkMO2 if MO2MODE is 'GUI'

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240116-5 (mo2-migrate-none)"
+PROGVERS="v14.0.20240116-5"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -6958,7 +6958,7 @@ function migrateCfgOption {
 			updateConfigEntry "SPEKVERS" "$SPEKVERS" "$STLGAMECFG"
 		fi
 
-		# stop MO2MODE from being 'none' in weird scenarios
+		# stop MO2MODE from being 'none' in weird scenarios -- Issue was confirmed to be exclusive to SteamOS and may be a (temporary?) SteamOS regression
 		if [ "$MO2MODE" == "$NON" ]; then
 			MO2MODE="disabled"
 			touch "$FUPDATE"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240116-3"
+PROGVERS="v14.0.20240116-4 (mo2-migrate-none)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -6962,7 +6962,7 @@ function migrateCfgOption {
 		if [ "$MO2MODE" == "$NON" ]; then
 			MO2MODE="disabled"
 			touch "$FUPDATE"
-			writelog "SKIP" "${FUNCNAME[0]} - ModOrganizer 2 variable MO2MODE is somehow '$NON' -- Defaulting this to 'disabled'"
+			writelog "INFO" "${FUNCNAME[0]} - ModOrganizer 2 variable MO2MODE is somehow '$NON' -- Defaulting this to 'disabled'"
 			updateConfigEntry "MO2MODE" "$MO2MODE" "$STLGAMECFG"
 		fi
 
@@ -17581,6 +17581,11 @@ function checkMO2 {
 		return
 	fi
 
+	if [ "$MO2MODE" == "disabled" ]; then
+		writelog "SKIP" "${FUNCNAME[0]} - MO2MODE is 'disabled' -- Skipping checkMO2!"
+		return
+	fi
+
 	# if [ "$MO2MODE" != "disabled" ]; then    # This check is because MO2 was once planned to have a silent mode, but no idea if/when this will be implemented, so just explicitly check for GUI
 	if [ "$MO2MODE" == "gui" ]; then
 		writelog "INFO" "${FUNCNAME[0]} - MO2MODE is '$MO2MODE' - starting MO2"
@@ -17609,8 +17614,8 @@ function checkMO2 {
 					}
 				;;
 				4)  {
-						writelog "INFO" "${FUNCNAME[0]} - Selected to start $MO with mods silently"
-						MO2MODE="silent"
+						writelog "INFO" "${FUNCNAME[0]} - Selected to start $MO with mods silently -- defaulting to gui since silent mode is not implemented"
+						MO2MODE="gui"
 					}
 				;;
 				6)  {

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240116-2"
+PROGVERS="v14.0.20240116-3"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -6956,6 +6956,14 @@ function migrateCfgOption {
 			touch "$FUPDATE"
 			writelog "INFO" "${FUNCNAME[0]} - Automatically updating variable SPEKVERS from 'old' to '$SPEKVERS' in '$STLGAMECFG'"
 			updateConfigEntry "SPEKVERS" "$SPEKVERS" "$STLGAMECFG"
+		fi
+
+		# stop MO2MODE from being 'none' in weird scenarios
+		if [ "$MO2MODE" == "$NON" ]; then
+			MO2MODE="disabled"
+			touch "$FUPDATE"
+			writelog "SKIP" "${FUNCNAME[0]} - ModOrganizer 2 variable MO2MODE is somehow '$NON' -- Defaulting this to 'disabled'"
+			updateConfigEntry "MO2MODE" "$MO2MODE" "$STLGAMECFG"
 		fi
 
 		# collections update
@@ -17567,7 +17575,14 @@ function setMO2DLMime {
 }
 
 function checkMO2 {
-	if [ "$MO2MODE" != "disabled" ]; then
+	# migrateCfgOption should mean this never happens, but can never be too careful -- Has begun happening since 12/01/2024 for a small number of Steam Deck users
+	if [ "$MO2MODE" == "$NON" ]; then
+		writelog "SKIP" "${FUNCNAME[0]} - MO2MODE is '$NON' -- This should not happen but has been observed in the wild, so explicitly returning here"
+		return
+	fi
+
+	# if [ "$MO2MODE" != "disabled" ]; then    # This check is because MO2 was once planned to have a silent mode, but no idea if/when this will be implemented, so just explicitly check for GUI
+	if [ "$MO2MODE" == "gui" ]; then
 		writelog "INFO" "${FUNCNAME[0]} - MO2MODE is '$MO2MODE' - starting MO2"
 
 		if [ "$WAITMO2" -gt 0 ]; then

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240116-5"
+PROGVERS="v14.0.20240119-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240116-4 (mo2-migrate-none)"
+PROGVERS="v14.0.20240116-5 (mo2-migrate-none)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -17637,6 +17637,8 @@ function checkMO2 {
 			writelog "INFO" "${FUNCNAME[0]} - Disabling custom command, because $MO2 is enabled"
 			USECUSTOMCMD=0
 		fi
+	else
+		writelog "WARN" "${FUNCNAME[0]} - Unknown MO2MODE value '$MO2MODE' -- This is safe as checkMO2 has been skipped, but it is still unusual"
 	fi
 }
 


### PR DESCRIPTION
Resolves an issue observed in the log for #1012.
May help #1016, very little information was provided to dianogse if it was the same problem.

## Overview
It has been reported that a couple of games somehow get into a state where `MO2MODE` is `none` (or `$NON`). This shouldn't happen, and so far has only been actually confirmed to happen with one game for one user and only on SteamOS (#1012, happened with Harvestella). A fresh install fixes this issue. In the log for #1012, I observed `MO2MODE` was `none`.

This would explain two things:
1. ModOrganizer 2 is launched in `checkMO2` if `MO2MODE != disabled`. Of course, `none != disabled`, so it tries to launch whenever a game config gets in this state, where `MO2MODE = none`.
2. A clean install fixes this because it re-creates the config files, thus re-creating the config file properly.

Nowhere in the code is `MO2MODE` set to `none`, so this must be some config file defaulting that incorrectly sets the value. However, none of my config files have this value, including a couple of games never launched with SteamTinkerLaunch until just now. So I'm not sure how this actually happens. I suspect it could be somehow isolated to Steam Deck usage, but I don't know what would be causing it there.

## Implementation
As a fix, I have made the followiing changes:
1. Add a migration in `migrateCfgOption` that forces `MO2MODE = disabled` if `MO2MODE` is `none`. This should fix config files that got in a bad state somehow with this invalid value.
2. Change `checkMO2` to only launch on `$MO2MODE = gui`. Previously there were plans for a silent mode, but as I don't use MO2 and don't work on that, and no one else has shown any interest, for now we will only launch on `gui`. This makes sense
3. Exit early in `checkMO2` if we have `MO2MODE = none`. This should never happen now because of `migrateCfgOption`, but it is an extra bit of insurance. We also have some logging for this.
4. When a user tries to launch MO2 in silent mode, since this is not implemented, default to `gui`. This was not an issue before since we only prevented launch on `MO2MODE = disabled`, but now we are skipping that.
5. Exit early if `MO2MODE = disabled`, not all that important to functionality but results in cleaner code.

This all needs extensively tested and some keen review from myself, but this should hopefully resolve the problems. If more information is provided in #1016 we can see if it resolves that issue too.

<hr>

I suspect, somehow, this is related to custom commands in the case of #1012. But I have no idea, really. At the very least this should prevent it from happening.