### PR TITLE
GameScope: Properly handle empty GAMESCOPE_ARGS string

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240305-1 (better-gamescope-empty-args-fix)"
+PROGVERS="v14.0.20240307-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -6,7 +6,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240218-1"
+PROGVERS="v14.0.20240305-1 (better-gamescope-empty-args-fix)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -19957,49 +19957,57 @@ function gameScopeArgs {  # This implementation could be VASTLY improved!
 	ARGSTRING="$1"
 	unset GAMESCOPEARGSARR
 
-	if [ "$1" != "$NON" ]; then
-		# This removes paths from the GameScope args array as spaces in paths can cause issues, then builds the array, and then re-inserts the paths where it finds empty single-quotes which we wrap paths with in GameScopeGui.
-		# When saving from the main menu, single quotes seem to get cleared, so we need to ensure paths are wrapped with them
-
-		# Store paths from GameScope array string
-		IFS_backup=$IFS
-		IFS=$'\n'
-		mapfile -t GAMESCOPE_ARGPATHS < <( echo "$ARGSTRING" | grep -oP "'/(.+?)'" )
-		writelog "INFO" "${FUNCNAME[0]} - GameScope incoming args are '${ARGSTRING[*]}'"
-		# If the above is empty, try and surround any existing paths with quotes and then grep for the file paths from the quotes - This means paths cannot contain quotes, but oh well. Compromise!
-		if [ -z "${GAMESCOPE_ARGPATHS[*]}" ]; then
-			writelog "INFO" "${FUNCNAME[0]} - Could not find any paths from incoming GameScope arguments, checking if we need to surround any paths in quotes..."
-			unset GAMESCOPE_ARGPATHS
-
-			# shellcheck disable=SC2001
-			ARGSTRING="$(echo "${ARGSTRING}" | sed "s:\(/\S* \S*\):'\1':g" )"  # Finds paths and surrounds them in single quotes so the below grep works!
-			mapfile -t GAMESCOPE_ARGPATHS < <( echo "$ARGSTRING" | grep -oP "'/(.+?)'" )
-			if [ -n "${GAMESCOPE_ARGPATHS[*]}" ]; then
-				writelog "INFO" "${FUNCNAME[0]} - We found some paths we need to update - Updated GameScope args string is '$ARGSTRING'"
-			else
-				writelog "INFO" "${FUNCNAME[0]} - Still could not find any paths from incoming GameScope arguments, assuming we don't have any paths in our arguments"
-			fi
-		fi
-		IFS=$IFS_backup
-
-		# Remove all text between single quotes -- We assume all text between single quotes in this context will be a GameScope path arg
-		writelog "INFO" "${FUNCNAME[0]} - GameScope arg paths are '${GAMESCOPE_ARGPATHS[*]}'"
-		# shellcheck disable=SC2001
-		ARGSTRING="$( echo "$ARGSTRING" | sed "s:'[^']*':'':g" )"
-		mapfile -d " " -t -O "${#GAMESCOPEARGSARR[@]}" GAMESCOPEARGSARR < <(printf '%s' "$ARGSTRING")
-
-		INSERTARG=$((0))  # Which path arg to insert from the `GAMESCOPE_ARGPATHS` array
-		GAMESCOPEARGSARR_COPY=("${GAMESCOPEARGSARR[@]}")
-		for i in "${!GAMESCOPEARGSARR_COPY[@]}"; do
-			if [[ "${GAMESCOPEARGSARR_COPY[$i]}" == *"'"* ]]; then
-				GAMESCOPEARGSARR_COPY[$i]="${GAMESCOPE_ARGPATHS[${INSERTARG}]}"
-				INSERTARG=$((INSERTARG + 1))
-			fi
-		done
-
-		unset GAMESCOPEARGSARR  # Reset array and re-assign it to copied array with updated argument values
-		GAMESCOPEARGSARR=("${GAMESCOPEARGSARR_COPY[@]}")
+	# Even if no args are given we always have to end GameScope commands with '--'
+	# $1 == NON when we save with no arguments, doing this visually preserves the GameScope "none" text while still gracefully handling blank args by forcing '--'
+	if [ "$1" == "$NON" ] || [ -z "$( trimWhitespaces "$1" )" ]; then  # trimWhitespaces accounts for strings that are just whitespaces, i.e. '     '
+		writelog "INFO" "${FUNCNAME[0]} - No gamescope arguments given, but we need to end with '--', so forcing GAMESCOPEARGSARR to '--' and returning"
+		GAMESCOPEARGSARR=("--")
+		return
 	fi
+
+	# This removes paths from the GameScope args array as spaces in paths can cause issues, then builds the array, and then re-inserts the paths where it finds empty single-quotes which we wrap paths with in GameScopeGui.
+	# When saving from the main menu, single quotes seem to get cleared, so we need to ensure paths are wrapped with them
+
+	# Store paths from GameScope array string
+	IFS_backup=$IFS
+	IFS=$'\n'
+	mapfile -t GAMESCOPE_ARGPATHS < <( echo "$ARGSTRING" | grep -oP "'/(.+?)'" )
+	writelog "INFO" "${FUNCNAME[0]} - GameScope incoming args are '${ARGSTRING[*]}'"
+	# If the above is empty, try and surround any existing paths with quotes and then grep for the file paths from the quotes - This means paths cannot contain quotes, but oh well. Compromise!
+	if [ -z "${GAMESCOPE_ARGPATHS[*]}" ]; then
+		writelog "INFO" "${FUNCNAME[0]} - Could not find any paths from incoming GameScope arguments, checking if we need to surround any paths in quotes..."
+		unset GAMESCOPE_ARGPATHS
+
+		# shellcheck disable=SC2001
+		ARGSTRING="$(echo "${ARGSTRING}" | sed "s:\(/\S* \S*\):'\1':g" )"  # Finds paths and surrounds them in single quotes so the below grep works!
+		mapfile -t GAMESCOPE_ARGPATHS < <( echo "$ARGSTRING" | grep -oP "'/(.+?)'" )
+		if [ -n "${GAMESCOPE_ARGPATHS[*]}" ]; then
+			writelog "INFO" "${FUNCNAME[0]} - We found some paths we need to update - Updated GameScope args string is '$ARGSTRING'"
+		else
+			writelog "INFO" "${FUNCNAME[0]} - Still could not find any paths from incoming GameScope arguments, assuming we don't have any paths in our arguments"
+		fi
+	fi
+	IFS=$IFS_backup
+
+	# Remove all text between single quotes -- We assume all text between single quotes in this context will be a GameScope path arg
+	writelog "INFO" "${FUNCNAME[0]} - GameScope arg paths are '${GAMESCOPE_ARGPATHS[*]}'"
+	# shellcheck disable=SC2001
+	ARGSTRING="$( echo "$ARGSTRING" | sed "s:'[^']*':'':g" )"
+	mapfile -d " " -t -O "${#GAMESCOPEARGSARR[@]}" GAMESCOPEARGSARR < <(printf '%s' "$ARGSTRING")
+
+	INSERTARG=$((0))  # Which path arg to insert from the `GAMESCOPE_ARGPATHS` array
+	GAMESCOPEARGSARR_COPY=("${GAMESCOPEARGSARR[@]}")
+	for i in "${!GAMESCOPEARGSARR_COPY[@]}"; do
+		if [[ "${GAMESCOPEARGSARR_COPY[$i]}" == *"'"* ]]; then
+			GAMESCOPEARGSARR_COPY[$i]="${GAMESCOPE_ARGPATHS[${INSERTARG}]}"
+			INSERTARG=$((INSERTARG + 1))
+		fi
+	done
+
+	unset GAMESCOPEARGSARR  # Reset array and re-assign it to copied array with updated argument values
+	GAMESCOPEARGSARR=("${GAMESCOPEARGSARR_COPY[@]}")
+
+	## TODO handle GameScope arguments that don't end in `--`
 
 	if [ "${#GAMESCOPEARGSARR[@]}" -ge 1 ]; then
 		writelog "INFO" "${FUNCNAME[0]} - Using following gamescope arguments: '${GAMESCOPEARGSARR[*]}'"


### PR DESCRIPTION
Fix part of #1048.

## Overview
This PR fixes a crash when GameScope arguments are blank. GameScope commands have to be ended with `--` to denote the en of the arguments list. If the user manually edits the GameScope args on the Game Menu and clears them out, 

This case is handled correctly by the GameScope GUI, so this only applies to editing the GameScope arguments string on the Game Menu or manually editing the per-game config file.

## Problem
With our GameScope args on the main menu, if they are totally empty, we set them to `$NON`. In our function `gameScopeArgs`, we give it `GAMESCOPE_ARGS` (our per-game config string) and then build the GameScope arguments in a format that we can pass as a launch command, split up into an array called `GAMESCOPEARGSARR`.

However, we only build `GAMESCOPEARGSARR` if the value we give to `gameScopeArgs` is not `$NON`. This means if it is, such as in the case of having an empty `GAMESCOPE_ARGS` string, we are simply passing nothing. This is a problem, because even if no arguments are given, GameScope commands *have* to be terminated with `--`. For SteamTinkerLaunch, blank GameScope arguments means everything after our GameScope binary (i.e. the rest of the launch command, as GameScope usually goes first) is being interpreted by GameScope as a parameter!

In the case of launching Proton games, this would mean our command looks like this: `/usr/bin/gamescope /home/gaben/.local/share/Steam/steamapps/common/Proton 8.0/proton --verb=waitforexitandrun -- /path/to/game.exe`. The problem here is that there is no `--` after the GameScope command, which will cause a crash.

## Solution
This PR fixes the above problem by checking if the arguments string given to `gameScopeArgs` is either `$NON` or blank (including an empty string like `'     '`, just an empty string with whitespaces), and if it is, simply set `GAMESCOPEARGSARR` to have `--` and return early. This also removes our nested `if` logic and flattens the function a little bit.

I tested a game running with Proton 9.0 (Beta) (Cookie Clicker), and a native Linux game (shapez). Both appeared to work fine, and this does not appear to impact defined GameScope arguments, so I am not seeing any regressions.

<hr>

TODO:
- [x] A little more testing
- [x] Shellcheck