### PR TITLE
ShellCheck: Set directive 'extended-analysis=false'

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # shellcheck source=/dev/null
+# shellcheck extended-analysis=false
 
 ### project ###
 
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240307-3"
+PROGVERS="v14.0.20240316-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"


### PR DESCRIPTION
*(See also: koalaman/shellcheck#2652)*
Prerequisite to #1056.

New directive available in ShellCheck v0.10.0. Fixes a memory issue with the DFA introduced in ShellCheck v0.9.0, which is why STL was stuck using v0.8.0. Now we can use newer ShellCheck version again!