### PR TITLE
URLs: Update steamtinkerlaunch-tweaks URL

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240316-2"
+PROGVERS="v14.0.20240316-3"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -3007,7 +3007,7 @@ function setDefaultCfgValues {
 		if [ -z "$PROJECTPAGE" ]						; then	PROJECTPAGE="$GHURL/sonic2kk/steamtinkerlaunch"; fi
 		if [ -z "$CP_PROTONTKG" ]						; then	CP_PROTONTKG="$GHURL/Frogging-Family/wine-tkg-git"; fi
 		if [ -z "$CP_PROTONGE" ]						; then	CP_PROTONGE="$GHURL/GloriousEggroll/proton-ge-custom"; fi
-		if [ -z "$CP_PROTONSTL" ]						; then	CP_PROTONSTL="$GHURL/frostworx/steamtinkerlaunch-tweaks"; fi
+		if [ -z "$CP_PROTONSTL" ]						; then	CP_PROTONSTL="$GHURL/sonic2kk/steamtinkerlaunch-tweaks"; fi
 		if [ -z "$DL_D3D47_64" ]						; then	DL_D3D47_64="https://lutris.net/files/tools/dll/$D3D47"; fi
 		if [ -z "$DL_D3D47_32" ]						; then	DL_D3D47_32="http://dege.freeweb.hu/dgVoodoo2/bin/D3DCompiler_47.zip"; fi
 		if [ -z "$RESHADEDLURL" ]						; then	RESHADEDLURL="https://reshade.me/downloads"; fi
@@ -3035,7 +3035,7 @@ function setDefaultCfgValues {
 		if [ -z "$SPEKGHURL" ]							; then	SPEKGHURL="$GHURL/${SPEK}O/${SPEK}/releases";fi
 		if [ -z "$SPEKCOMPURL" ]						; then	SPEKCOMPURL="https://www.pcgamingwiki.com/wiki/List_of_games_compatible_with_Special_K#Compatibility_list";fi
 		if [ -z "$FWSURL" ]								; then	FWSURL="https://www.${FWS,,}.org/fws";fi
-		if [ -z "$YAIURL" ]								; then	YAIURL="$GHURL/frostworx/steamtinkerlaunch-tweaks/releases/download"; fi
+		if [ -z "$YAIURL" ]								; then	YAIURL="$GHURL/sonic2kk/steamtinkerlaunch-tweaks/releases/download"; fi
 		if [ -z "$WINERELOADURL" ]						; then	WINERELOADURL="https://gist.githubusercontent.com/rbernon/cdbdc1b0e892f91e7449fcf3dda80bb7/raw/d8cf549bf751d99ed0fe515e36f99ff5c01b7287"; fi
 		if [ -z "$GEOELFURL" ]							; then	GEOELFURL="http://helixmod.blogspot.com/2022/06/announcing-new-geo-11-3d-driver.html"; fi
 		if [ -z "$WDIBURL" ]							; then	WDIBURL="$GHURL/0e4ef622/$WDIB/releases"; fi
@@ -18128,7 +18128,7 @@ function setYadBin {
 				export ONSTEAMDECK=1
 				YADAIDLDIR="$STLSDPATH"
 				YAIDST="$YADAIDLDIR/$YADAPPIMAGE"
-				YAIURL="$GHURL/frostworx/steamtinkerlaunch-tweaks/releases/download"
+				YAIURL="$GHURL/sonic2kk/steamtinkerlaunch-tweaks/releases/download"  # TODO isn't this already defined in URLs with the same namd and path?
 				YAIDL="$YAIURL/$YADSTLIMAGE/$YADSTLIMAGE"
 				YADAPPIMAGE="$YADSTLIMAGE"
 


### PR DESCRIPTION
Now [sonic2kk/steamtinkerlaunch-tweaks](https://github.com/sonic2kk/steamtinkerlaunch-tweaks/), see #1060. The URL will automatically redirect anyway, this is just for consistency.

There is a TODO around checking if `YAIURL` is a duplicate in . I think it is, but I won't touch it in this PR as I don't want to break things.