### PR TITLE
ShellCheck: Fix warnings since ShellCheck v0.10.0

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240316-5 (shellcheck-0-10-0-fixes)"
+PROGVERS="v14.0.20240317-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240316-3"
+PROGVERS="v14.0.20240316-3 (shellcheck-0-10-0-fixes)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -2526,6 +2526,8 @@ function setCustomGameVars {
 	fi
 }
 
+# TODO: This does not work on Wayland!
+# Add logging and update langfiles
 function prepareGUI {
 	WINDECO="--undecorated"
 	if [ -n "$USEWINDECO" ]; then
@@ -4298,7 +4300,7 @@ function needNewProton {
 		writelog "INFO" "${FUNCNAME[0]} - No Proton Version was found - opening a requester to choose from one"
 		createProtonList
 
-		PICKPROTON="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --center $WINDECO --form --scroll --separator="\n" --quoted-output \
+		PICKPROTON="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --center "$WINDECO" --form --scroll --separator="\n" --quoted-output \
 		--text="$(spanFont "$GUI_NEEDNEWPROTON" "H")" \
 		--field="$GUI_NEEDNEWPROTON2":CB "$(cleanDropDown "${USEPROTON/#-/ -}" "$PROTYADLIST")" \
 		--title="$TITLE" "$GEOM")"
@@ -4465,7 +4467,7 @@ function dlCustomProtonGUI {
 		DLPROTON="${ProtonDLDispList[0]}"
 	fi
 
-	DLDISPCUSTPROT="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --form --center --on-top $WINDECO \
+	DLDISPCUSTPROT="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --form --center --on-top "$WINDECO" \
 	--title="$TITLE" \
 	--text="$(spanFont "$GUI_DLCUSTPROTTEXT" "H")" \
 	--field=" ":LBL " " --separator="" \
@@ -4780,7 +4782,7 @@ function addCustomProton {
 		TITLE="${PROGNAME}-AddCustomProton"
 		pollWinRes "$TITLE"
 
-		NEWCUSTPROT="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --form --center --on-top $WINDECO \
+		NEWCUSTPROT="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --form --center --on-top "$WINDECO" \
 		--title="$TITLE" \
 		--text="$(spanFont "$GUI_ADDCUSTOMBINARY" "H")" \
 		--field=" ":LBL " " \
@@ -5163,7 +5165,7 @@ function EditorDialog {
 	setShowPic
 
 	EDFILES="$(while read -r f; do	echo "FALSE"; echo "$f"; done <<< "$(printf "%s\n" "${CfgFiles[@]}" | sort -u)" | \
-	"$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --center $WINDECO --list --checklist --column=Edit --column=ConfigFile --separator="\n" --print-column="2" \
+	"$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --center "$WINDECO" --list --checklist --column=Edit --column=ConfigFile --separator="\n" --print-column="2" \
 	--text="$(spanFont "$(strFix "$GUI_EDITORDIALOG" "$SGNAID")" "H")" --title="$TITLE" --button="$BUT_EDIT":0 --button="$BUT_HIDE":2 --button="$BUT_OD":4 --button="$BUT_DEL":6 --button="$BUT_CAN":8 "$GEOM")"
 	case $? in
 		0)  {
@@ -5619,27 +5621,27 @@ function AllSettingsEntriesDummyFunction {
 --field="     $GUI_SGDBSTYLES!$DESC_SGDBSTYLES ('SGDBHEROSTYLES')":CBE "$(cleanDropDown "${SGDBHEROSTYLES/#-/ -}" "${SGDBHEROSTYLEOPTS//,/\!}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBNSFW!$DESC_SGDBNSFW ('SGDBHERONSFW')":CBE "$(cleanDropDown "${SGDBHERONSFW/#-/ -}" "${SGDBTAGOPTS}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBHUMOR!$DESC_SGDBHUMOR ('SGDBHEROHUMOR')":CBE "$(cleanDropDown "${SGDBHEROHUMOR/#-/ -}" "${SGDBTAGOPTS}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
---field="     $GUI_SGDBEPILEPSY!$DESC_SGDBEPILEPSY ('SGDBHEROEPILEPSY')":CBE "$(cleanDropDown ${SGDBHEROEPILEPSY/#-/ -} "$SGDBTAGOPTS")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
+--field="     $GUI_SGDBEPILEPSY!$DESC_SGDBEPILEPSY ('SGDBHEROEPILEPSY')":CBE "$(cleanDropDown "${SGDBHEROEPILEPSY/#-/ -}" "$SGDBTAGOPTS")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBDLLOGO!$DESC_SGDBDLLOGO ('SGDBDLLOGO')":CHK "${SGDBDLLOGO/#-/ -}" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBTYPES!$DESC_SGDBTYPES ('SGDBLOGOTYPES')":CBE "$(cleanDropDown "${SGDBLOGOTYPES/#-/ -}" "${SGDBTYPEOPTS}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBSTYLES!$DESC_SGDBSTYLES ('SGDBLOGOSTYLES')":CBE "$(cleanDropDown "${SGDBLOGOSTYLES/#-/ -}" "${SGDBLOGOSTYLEOPTS//,/\!}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBNSFW!$DESC_SGDBNSFW ('SGDBLOGONSFW')":CBE "$(cleanDropDown "${SGDBLOGONSFW/#-/ -}" "${SGDBTAGOPTS}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBHUMOR!$DESC_SGDBHUMOR ('SGDBLOGOHUMOR')":CBE "$(cleanDropDown "${SGDBLOGOHUMOR/#-/ -}" "${SGDBTAGOPTS}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
---field="     $GUI_SGDBEPILEPSY!$DESC_SGDBEPILEPSY ('SGDBLOGOEPILEPSY')":CBE "$(cleanDropDown ${SGDBLOGOEPILEPSY/#-/ -} "$SGDBTAGOPTS")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
+--field="     $GUI_SGDBEPILEPSY!$DESC_SGDBEPILEPSY ('SGDBLOGOEPILEPSY')":CBE "$(cleanDropDown "${SGDBLOGOEPILEPSY/#-/ -}" "$SGDBTAGOPTS")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBDLBOXART!$DESC_SGDBDLBOXART ('SGDBDLBOXART')":CHK "${SGDBDLBOXART/#-/ -}" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBDIMS!$DESC_SGDBDIMS ('SGDBBOXARTDIMS')":CBE "$(cleanDropDown "${SGDBBOXARTDIMS/#-/ -}" "${DEFSGDBBOXARTDIMS//,/\!}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBTYPES!$DESC_SGDBTYPES ('SGDBBOXARTTYPES')":CBE "$(cleanDropDown "${SGDBBOXARTTYPES/#-/ -}" "${SGDBTYPEOPTS}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBSTYLES!$DESC_SGDBSTYLES ('SGDBBOXARTSTYLES')":CBE "$(cleanDropDown "${SGDBBOXARTSTYLES/#-/ -}" "${SGDBGRIDSTYLEOPTS//,/\!}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBNSFW!$DESC_SGDBNSFW ('SGDBBOXARTNSFW')":CBE "$(cleanDropDown "${SGDBBOXARTNSFW/#-/ -}" "${SGDBTAGOPTS}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBHUMOR!$DESC_SGDBHUMOR ('SGDBBOXARTHUMOR')":CBE "$(cleanDropDown "${SGDBBOXARTHUMOR/#-/ -}" "${SGDBTAGOPTS}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
---field="     $GUI_SGDBEPILEPSY!$DESC_SGDBEPILEPSY ('SGDBBOXARTEPILEPSY')":CBE "$(cleanDropDown ${SGDBBOXARTEPILEPSY/#-/ -} "$SGDBTAGOPTS")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
+--field="     $GUI_SGDBEPILEPSY!$DESC_SGDBEPILEPSY ('SGDBBOXARTEPILEPSY')":CBE "$(cleanDropDown "${SGDBBOXARTEPILEPSY/#-/ -}" "$SGDBTAGOPTS")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBDLTENFOOT!$DESC_SGDBDLTENFOOT ('SGDBDLTENFOOT')":CHK "${SGDBDLTENFOOT/#-/ -}" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBDIMS!$DESC_SGDBDIMS ('SGDBTENFOOTDIMS')":CBE "$(cleanDropDown "${SGDBTENFOOTDIMS/#-/ -}" "${DEFSGDBTENFOOTDIMS//,/\!}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBTYPES!$DESC_SGDBTYPES ('SGDBTENFOOTTYPES')":CBE "$(cleanDropDown "${SGDBTENFOOTTYPES/#-/ -}" "${SGDBTYPEOPTS}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBSTYLES!$DESC_SGDBSTYLES ('SGDBTENFOOTSTYLES')":CBE "$(cleanDropDown "${SGDBTENFOOTSTYLES/#-/ -}" "${SGDBTNFTSTYLEOPTS//,/\!}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBNSFW!$DESC_SGDBNSFW ('SGDBTENFOOTNSFW')":CBE "$(cleanDropDown "${SGDBTENFOOTNSFW/#-/ -}" "${SGDBTAGOPTS}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="     $GUI_SGDBHUMOR!$DESC_SGDBHUMOR ('SGDBTENFOOTHUMOR')":CBE "$(cleanDropDown "${SGDBTENFOOTHUMOR/#-/ -}" "${SGDBTAGOPTS}")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
---field="     $GUI_SGDBEPILEPSY!$DESC_SGDBEPILEPSY ('SGDBTENFOOTEPILEPSY')":CBE "$(cleanDropDown ${SGDBTENFOOTEPILEPSY/#-/ -} "$SGDBTAGOPTS")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
+--field="     $GUI_SGDBEPILEPSY!$DESC_SGDBEPILEPSY ('SGDBTENFOOTEPILEPSY')":CBE "$(cleanDropDown "${SGDBTENFOOTEPILEPSY/#-/ -}" "$SGDBTAGOPTS")" `#CAT_SteamGridDB` `#MENU_GLOBAL` \
 --field="$(spanFont "$GUI_OPTSHMM" "H")":LBL "SKIP" `#CAT_HMM` `#HEAD_HMM` `#MENU_GLOBAL` \
 --field="     $GUI_HMMDLVER!$DESC_HMMDLVER ('HMMDLVER')":CB "$(cleanDropDown "${HMMDLVER/#-/ -}" "$HMMSTABLE!$HMMDEV")" `#CAT_HMM` `#MENU_GLOBAL` \
 --field="     $GUI_HMMCOMPDATA!$DESC_HMMCOMPDATA ('HMMCOMPDATA')":DIR "${HMMCOMPDATA/#-/ -}" `#CAT_HMM` `#SUB_Directories` `#MENU_GLOBAL` \
@@ -6067,7 +6069,7 @@ function openCustMenu {
 	{
 		echo "function $MYFUNC {"
 		echo "\"$YAD\" --columns=\"$COLCOUNT\" --f1-action=\"$F1ACTIONCG\" --text=\"$(spanFont "$MYTEXT" "H")\" \\"
-		echo "--title=\"$TITLE\" --image \"$FAVPIC\" --image-on-top --window-icon=\"$STLICON\" --center $WINDECO --form --separator=\"\\n\" --quoted-output \\"
+		echo "--title=\"$TITLE\" --image \"$FAVPIC\" --image-on-top --window-icon=\"$STLICON\" --center \"$WINDECO\" --form --separator=\"\\n\" --quoted-output \\"
 		echo "--button=\"$BUT0\":0 --button=\"$BUT2\":2 --button=\"$BUT4\":4 --button=\"$BUT6\":6 --button=\"$BUT8\":8 --button=\"$BUT10\":10 $GEOM \\"
 		cat "$MYTMPL"
 		echo "--scroll"
@@ -6147,7 +6149,7 @@ function setGuiSortOrder {
 
 	NEWSORT="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --center --on-top "$WINDECO" \
 		--list --editable --column "Category" --separator="" --print-all \
-		--title="$TITLE" --text="$(spanFont "$GUI_SORTCAT" "H")" $GEOM < "$STLMENUSORTCFG")"
+		--title="$TITLE" --text="$(spanFont "$GUI_SORTCAT" "H")" "$GEOM" < "$STLMENUSORTCFG")"
 	case $? in
 		0) 	{
 				writelog "INFO" "${FUNCNAME[0]} - Clicked OK - Saving new sortorder into '$STLMENUSORTCFG'"
@@ -6169,7 +6171,7 @@ function setGuiFavoritesSelection {
 	setShowPic
 
 	FAVENTRIES="$(favoritesMenuEntries | \
-	"$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --center $WINDECO --list --checklist \
+	"$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --center "$WINDECO" --list --checklist \
 	--column="$GUI_ADD" --column="$GUI_DESC" --column="$GUI_VAR" --column="LongDesc" --separator="\n" --print-column="3" --tooltip-column 4 --hide-column 4 \
 	--text="$(spanFont "$GUI_FAVORITESSEL" "H")" --title="$TITLE" "$GEOM")"
 	case $? in
@@ -6252,7 +6254,7 @@ function setGuiCategoryMenuSel {
 
 	CATDD="$(cleanDropDown "${GCD}" "$(getCatsFromCode | tr '\n' '!' | sed "s:^!::" | sed "s:!$::")")"
 
-	SELECTCAT="$("$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --center $WINDECO --form --separator="\n" \
+	SELECTCAT="$("$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --center "$WINDECO" --form --separator="\n" \
 	--text="$(spanFont "$(strFix "$GUI_CATSEL" "$PROGNAME")" "H")" \
 	--title="$TITLE" --field=" $GUI_CAT!$(strFix "$GUI_CATSEL" "$PROGNAME")":CB "$CATDD" "$GEOM")"
 	case $? in
@@ -7784,10 +7786,10 @@ function listSteamGames {
 
 				# Only display game dir if the game is installed, i.e. if getGameDir does not return 1
 				# This means we won't return an error if we're returning OWNED games, as some owned games may not have paths
-				if [ $GAMDIREXISTS -eq 1 ]; then
+				if [ "$GAMDIREXISTS" -eq 1 ]; then
 					GAMNAM="$( getTitleFromID "$AID" )"
 					GAMNAMEXISTS=$?
-					if [ $GAMNAMEXISTS -eq 1 ]; then
+					if [ "$GAMNAMEXISTS" -eq 1 ]; then
 						echo "$AID"  # Game name unknown, probably never installed before? Just return AppID in this case
 					else
 						echo "$GAMNAM ($AID)"
@@ -9701,7 +9703,7 @@ function removeReShadeSpecialKInstallation {
 
 	# INI file
 	if [ "$KEEPRESHADEINI" -eq 1 ]; then
-		rmFileIfExists ""$INSTDESTDIR/$RSINI""
+		rmFileIfExists "$INSTDESTDIR/$RSINI"
 	fi
 }
 
@@ -11423,7 +11425,7 @@ function GameScopeGui {
 	setGameScopeVars  # Get values for UI elements below
 
 	# GameScope Yad options form
-	GASCOS="$("$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --scroll --window-icon="$STLICON" --form --center --on-top $WINDECO \
+	GASCOS="$("$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --scroll --window-icon="$STLICON" --form --center --on-top "$WINDECO" \
 			--title="$TITLE" --separator="|" \
 			--text="$(spanFont "$(strFix "$GUI_GASCOSET" "$SGNAID")" "H")" \
 			--field="$(spanFont "$GUI_GSGENERALSET" "H")":LBL "SKIP" \
@@ -11804,7 +11806,7 @@ function StandaloneProtonGame {
 			IN_SAP_COMPAT_DATA_PATH="$SAP_COMPAT_DATA_PATH"
 		fi
 
-		PROTPARTS="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --form --center --on-top $WINDECO \
+		PROTPARTS="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --form --center --on-top "$WINDECO" \
 		--title="$TITLE" \
 		--text="$(spanFont "$GUI_SAPTEXT" "H")" \
 		--field=" ":LBL " " --separator="|" \
@@ -12292,7 +12294,7 @@ function OneTimeRunGui {
 	fi
 
 	# TODO GUI looks weird because of uneven number of checkboxes, but this will be fixed once we add a checkbox for Steam Linux Runtime as well
-	OTCMDS="$("$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --form --center --on-top $WINDECO \
+	OTCMDS="$("$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --form --center --on-top "$WINDECO" \
 		--title="$TITLE" --separator="|" \
 		--columns="2" \
 		--text="$(spanFont "$GUI_ONETIMERUN" "H")" \
@@ -12885,7 +12887,7 @@ function GameFilesMenu {
 
 		setShowPic
 		OPFILES="$(for i in "${!GamFiles[@]}"; do printf "FALSE\n%s\n%s\n" "${GamDesc[$i]}" "${GamFiles[$i]}"; done | \
-		"$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --center $WINDECO --list --checklist --column=Open --column=Description --column=Path --separator="\n" --print-column="3" \
+		"$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --center "$WINDECO" --list --checklist --column=Open --column=Description --column=Path --separator="\n" --print-column="3" \
 		--text="$(spanFont "$(strFix "$GUI_GAFIDIALOG" "$SGNAID")" "H")" --title="$TITLE" --button="$BUT_CAN:0" --button="$BUT_SELECT:2" "$GEOM")"
 		case $? in
 			0) writelog "INFO" "${FUNCNAME[0]} - Selected '$BUT_CAN' - Cancelling selection"
@@ -14207,7 +14209,7 @@ function chooseWinetricksPrefix {
 			WTPROTON="$USEPROTON"
 		fi
 
-		WTCATPFX="$("$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --form --center --on-top $WINDECO \
+		WTCATPFX="$("$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --form --center --on-top "$WINDECO" \
 		--title="$TITLE" --separator=";" \
 		--text="$(spanFont "$GUI_CHOOSEWTCATPFX" "H")" \
 		--field=" ":LBL " " \
@@ -15408,7 +15410,7 @@ function prepareHMMGames {
 
 		writelog "INFO" "${FUNCNAME[0]} - Checking if we need to apply any game-specific tweaks to improve mod compatibility"
 		prepareHMMGameWinetricks "$HMMGAID" "$HMMGPFX"
-	done <$HMMGAMES
+	done <"$HMMGAMES"
 	echo "Finished configuring installed HedgeModManager games"
 }
 
@@ -16919,7 +16921,7 @@ function installVortexGui {
 		GUI_VTXINST="$(printf '%s\n%s\n' "${GUI_VTXINST}" "Newest setup online: ${VSO}")"
 	fi
 
-	VTXINSTARGS="$("$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --form --center --on-top $WINDECO \
+	VTXINSTARGS="$("$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --form --center --on-top "$WINDECO" \
 		--title="$TITLE" --separator="|" \
 		--text="$(spanFont "$GUI_VTXINST" "H")" \
 		--field="$GUI_USEVORTEXPROTON!$DESC_USEVORTEXPROTON ('USEVORTEXPROTON')":CB "$(cleanDropDown "$USEVORTEXPROTON" "$PROTYADLIST")" \
@@ -17311,7 +17313,7 @@ function listMO2Games {
 		MO2GAMAID="$( echo "$MO2GAM" | cut -d ";" -f 2 | cut -d '"' -f 2 )"
 
 		printf "%s (%s)\n" "$MO2GAMNAM" "$MO2GAMAID"
-	done <$MO2GAMES
+	done <"$MO2GAMES"
 }
 
 function manageMO2GInstance {
@@ -19377,12 +19379,12 @@ function logPlayTime {
 		((m=(${1}%3600)/60))
 		((s=${1}%60))
 
-		if [ $h -gt 0 ]; then
-			printf "%02d hrs, %02d mins, %02d secs" $h $m $s
-		elif [ $m -gt 0 ]; then
-			printf "%02d mins, %02d secs" $m $s
+		if [ "$h" -gt 0 ]; then
+			printf "%02d hrs, %02d mins, %02d secs" "$h" "$m" "$s"
+		elif [ "$m" -gt 0 ]; then
+			printf "%02d mins, %02d secs" "$m" "$s"
 		else
-			printf "%02d secs" $s
+			printf "%02d secs" "$s"
 		fi
 	}
 
@@ -20710,7 +20712,7 @@ function dlWineGUI {
 		DLWINE="${WineDLDispList[0]}"
 	fi
 
-	DLDISPWINE="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --form --center --on-top $WINDECO \
+	DLDISPWINE="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --form --center --on-top "$WINDECO" \
 	--title="$TITLE" \
 	--text="$(spanFont "$GUI_DLWINETEXT" "H")" \
 	--field=" ":LBL " " \
@@ -20736,7 +20738,7 @@ function PickSpecificWine {
 	TITLE="${PROGNAME}-${FUNCNAME[0]}"
 	pollWinRes "$TITLE"
 
-	SPECWINE="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --form --center --on-top $WINDECO \
+	SPECWINE="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --form --center --on-top "$WINDECO" \
 	--title="$TITLE" --separator="|" \
 	--text="$(spanFont "GUI_DLSPECWINE" "H")" \
 	--field=" ":LBL " " \
@@ -20878,7 +20880,7 @@ function WineSelection {
 			export CURWIKI="$PPW/Wine-Support"
 			TITLE="${PROGNAME}-SelectedWine"
 			pollWinRes "$TITLE"
-			WINSEL="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --form --center --on-top $WINDECO \
+			WINSEL="$("$YAD" --f1-action="$F1ACTION" --window-icon="$STLICON" --form --center --on-top "$WINDECO" \
 			--title="$TITLE" \
 			--text="$(spanFont "$GUI_SELIWINE" "H")" \
 			--field=" ":LBL " " \
@@ -23121,7 +23123,7 @@ function restoreSteamUser {
 
 		"$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --center --on-top "$WINDECO" \
 		--title="$TITLE" \
-		--text="$(spanFont "$(strFix "$GUI_AR" "$BACKUPSRC" "$SteamUserDir")" "H")\n<i>$1</i>" $GEOM
+		--text="$(spanFont "$(strFix "$GUI_AR" "$BACKUPSRC" "$SteamUserDir")" "H")\n<i>$1</i>" "$GEOM"
 		case $? in
 			0) 	{
 					writelog "INFO" "${FUNCNAME[0]} - Restoring '$SteamUserDir' from '$BACKUPSRC' confirmed"
@@ -23871,7 +23873,7 @@ function SteamCatSelect {
 	unset VALTAGS
 	mapfile -d "\n" -t -O "${#VALTAGS[@]}" VALTAGS <<< "$(getActiveSteamCollections | grep -v "^rt[A-Z]")"
 	SCATSELOUT="$(while read -r f; do if [[ ! "${SCATSEL[*]}" =~ $f ]]; then 	echo FALSE ; echo "$f"; else echo TRUE ; echo "$f" ;fi ; done <<< "$(printf "%s\n" "${VALTAGS[@]}")" | \
-	"$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --center $WINDECO --list --checklist --column="" --column="Steam Collection" --separator="\n" --print-column="2" \
+	"$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --center "$WINDECO" --list --checklist --column="" --column="Steam Collection" --separator="\n" --print-column="2" \
 	--text="$(spanFont "$GUI_STEAMCATSEL" "H")" --title="$TITLE" --button="$BUT_SEL":0 --button="$BUT_CAN":2 "$GEOM")"
 
 	case $? in

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240316-4 (shellcheck-0-10-0-fixes)"
+PROGVERS="v14.0.20240316-5 (shellcheck-0-10-0-fixes)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -9780,11 +9780,13 @@ function createReShadeINI {
 			writelog "INFO" "${FUNCNAME[0]} - Re-enabling previously disabled '$FRSOINI'"
 			mv "$FRSOINI" "$FRSINI"
 		else
+			# This used to use echo but was changed to use printf to address ShellCheck SC2028
+			# In testing using both echo and printf produced the same string result, but if this causes issues we can re-evaluate
 			writelog "INFO" "${FUNCNAME[0]} - Creating initial '$FRSINI' with default paths pointing to '$RSSUB'"
 			{
 				echo "[GENERAL]"
-				echo "EffectSearchPaths=.\\$RSSUB\Shaders"
-				echo "TextureSearchPaths=.\\$RSSUB\Textures"
+				printf "EffectSearchPaths=.\\%s\Shaders\n" "$RSSUB"
+				printf "TextureSearchPaths=.\\%s\Textures\n" "$RSSUB"
 				echo "PreprocessorDefinitions=RESHADE_DEPTH_LINEARIZATION_FAR_PLANE=1000.0,RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN=0,RESHADE_DEPTH_INPUT_IS_REVERSED=1,RESHADE_DEPTH_INPUT_IS_LOGARITHMIC=0"
 			} > "$FRSINI"
 		fi
@@ -14872,7 +14874,7 @@ function setModGameSyms {
 						writelog "INFO" "${FUNCNAME[0]} - Game Dir is '$MEFD' - adding the windows variant into the registry, because it is required for this game"
 						grep -i -B2 "^\"installed path\"=" "$MSREG" | grep -v "^#\|LastKey\|CurrentVersion\|^--" | head -n1 | sed "s:^\[Software:\[HKEY_LOCAL_MACHINE\\\Software:" | sed "s:\\\\Wow6432Node::" >> "$MODGREG"
 						# the path could be grepped as well, but at least two games had the Steamworks Shared path in the reg value instead here
-						echo "\"installed path\"=\"Z:${MEFD//\//\\\\}\\\\\"" >> "$MODGREG"
+						printf "\"installed path\"=\"Z:%s\\\\\"\n" "${MEFD//\//\\\\}" >> "$MODGREG"
 					else
 						writelog "SKIP" "${FUNCNAME[0]} - Game Dir '$MEFD' not found"
 					fi
@@ -17365,17 +17367,21 @@ function manageMO2GInstance {
 							MO2GAZDI="Z:${MO2GADI//\//\\\\}"
 							mkProjDir "$MOIN"
 							touch "$MOININI"
+							# This used to use `echo` but was changed because of ShellCheck SC2028
+							# The behaviour was different too, echo was returning '\\\\' but printf was returning '\\'
+							# Based on the rest of the paths, I think printf's '\\' is actually correct, but if this breaks anything,
+							# we can re-evaluate.
 							{
 							echo "[General]"
 							echo "gameName=$MO2GAMINI"
 							echo "selected_profile=@ByteArray(Default)"
 							echo "gamePath=@ByteArray($MO2GAZDI)"
 							echo "[Settings]"
-							echo "download_directory=${GLOBZMOIN}\\\\downloads"
-							echo "cache_directory=${GLOBZMOIN}\\\\webcache"
-							echo "mod_directory=${GLOBZMOIN}\\\mods"
-							echo "overwrite_directory=${GLOBZMOIN}\\\\overwrite"
-							echo "profiles_directory=${GLOBZMOIN}\\\\profiles"
+							printf "download_directory=%s\\\\downloads\n" "${GLOBZMOIN}"
+							printf "cache_directory=%s\\\\webcache\n" "${GLOBZMOIN}"
+							printf "mod_directory=%s\\\mods\n" "${GLOBZMOIN}"
+							printf "overwrite_directory=%s\\\\overwrite\n" "${GLOBZMOIN}"
+							printf "profiles_directory=%s\\\\profiles\n" "${GLOBZMOIN}"
 							} >> "$MOININI"
 							MOINEW=1
 						else
@@ -22375,6 +22381,11 @@ function commandline {
 		fetchGameSLRGui "$2"
 	elif [ "$1" == "debug" ]; then
 		## Why are you looking here? :-)
+
+		# Don't let the user run the internal debug command
+		writelog "WARN" "${FUNCNAME[0]} - No debug for you!"
+		echo "No debug for you!"
+		return
 
 		# DEBUGNOSTAID="-222353304"
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240316-3 (shellcheck-0-10-0-fixes)"
+PROGVERS="v14.0.20240316-4 (shellcheck-0-10-0-fixes)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -20016,8 +20016,8 @@ function gameScopeArgs {  # This implementation could be VASTLY improved!
 	INSERTARG=$((0))  # Which path arg to insert from the `GAMESCOPE_ARGPATHS` array
 	GAMESCOPEARGSARR_COPY=("${GAMESCOPEARGSARR[@]}")
 	for i in "${!GAMESCOPEARGSARR_COPY[@]}"; do
-		if [[ "${GAMESCOPEARGSARR_COPY[$i]}" == *"'"* ]]; then
-			GAMESCOPEARGSARR_COPY[$i]="${GAMESCOPE_ARGPATHS[${INSERTARG}]}"
+		if [[ "${GAMESCOPEARGSARR_COPY[i]}" == *"'"* ]]; then
+			GAMESCOPEARGSARR_COPY[i]="${GAMESCOPE_ARGPATHS[${INSERTARG}]}"
 			INSERTARG=$((INSERTARG + 1))
 		fi
 	done
@@ -21642,7 +21642,7 @@ function launchSteamGame {
 			writelog "INFO" "${FUNCNAME[0]} - WAITFORCUSTOMCMD is enabled, so replacing $WFEAR with 'run' in'${FINALSTARTCMD[*]}'"
 			for i in "${!FINALSTARTCMD[@]}"; do
 				if [[ ${FINALSTARTCMD[$i]} == "$WFEAR" ]]; then
-					FINALSTARTCMD[$i]="run"
+					FINALSTARTCMD[i]="run"
 				fi
 			done
 		fi


### PR DESCRIPTION
Prerequisite to #1056.

## Overview
Fixes ShellCheck warnings not caught in v0.8.0 that are caught now that we can use v0.10.0.

ShellCheck v0.9.0 added a new data flow analysis engine, but this sucks up ram on certain scripts (not necessarily tied to length) including SteamTinkerLaunch, so we were stuck on v0.8.0, which is a couple years out of date.

Recently, ShellCheck v0.10.0 came out, and added an option to disable the new data analysis engine introduced in v0.9.0 with a directive. SteamTinkerLaunch now has this directive (#1061), so we can now use ShellCheck v0.10.0! Woohoo!

ShellCheck v0.10.0 flags up quite a lot of warnings that v0.8.0 didn't. They are all existing warnings but it's better at catching them. This PR will aim to address as many as possible, and from a quick glance, I think all of them can be addressed.

## Warning Types
The three main warning types we're running into now are:
- [SC2086](https://www.shellcheck.net/wiki/SC2086): Use quotes to prevent word globbing.
- [SC2028](https://www.shellcheck.net/wiki/SC2028): Echo may not expand escape sequences.
- [SC2004](https://www.shellcheck.net/wiki/SC2004): `$/${}` is unnecessary for arithmetic variables.

I will address each of these in their own commit.

<hr>

Opening now but only SC2086 has been dealt with so far. I confirmed that adding the quotes was safe.

SC2004 should be straightforward enough too, but I am concerned about solving 2028 without breaking functionality. It will probably be sorted out last.