### PR TITLE
ci(shellcheck): Change workflow to run on PR label event

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   shellcheck:
-    if: ${{ ( github.event_name == 'pull_request' && github.event.label.name == "shellcheck" ) || github.event.pull_request.merged == true }}
+    if: ${{ github.event_name == 'pull_request' && github.event.label.name == "shellcheck" }}
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,15 +2,19 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'steamtinkerlaunch'
   pull_request:
     types: [ labeled ]
+    paths:
+      - 'steamtinkerlaunch'
 
 name: "ShellCheck"
 permissions: {}
 
 jobs:
   shellcheck:
-    if: ${{ github.event.label.name == "shellcheck" }}
+    if: ${{ ( github.event_name == 'pull_request' && github.event.label.name == "shellcheck" ) || github.event.pull_request.merged == true }}
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,13 +3,14 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, reopened]
+    types: [ labeled ]
 
 name: "ShellCheck"
 permissions: {}
 
 jobs:
   shellcheck:
+    if: ${{ github.event.label.name == "shellcheck" }}
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   shellcheck:
-    if: ${{ github.event_name == 'pull_request' && github.event.label.name == "shellcheck" }}
+    if: ${{ (github.event_name == 'pull_request' && github.event.label.name == "shellcheck") || (github.event_name == 'push' && github.ref == 'refs/heads/master') }}
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Instead of running ShellCheck when a PR is opened, we should run it when a PR is labelled. Outside of PRs, we should run the workflow on merge, but only for the master branch.

In other words, our ShellCheck Action should run in the following conditions:
- When there is a push to master (such as on merge).
- When a PR is labelled with "shellcheck".
- For both of the above, only run on the `steamtinkerlaunch` file.

Still finding my feet with these workflows, but I think it should be fine.