### PR TITLE
Purposely break to test ShellCheck CI

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -17679,7 +17679,7 @@ function checkMO2 {
 			pollWinRes "$TITLE"
 
 			setShowPic
-			"$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --form --center --on-top "$WINDECO" \
+			"$YAD" --f1-action="$F1ACTION" --image "$SHOWPIC" --image-on-top --window-icon="$STLICON" --form --center --on-top $WINDECO \
 			--title="$TITLE" \
 			--text="$(spanFont "$SGNAID - $GUI_ASKMO2" "H")" \
 			--button="$BUT_MO2_GUI":0 \


### PR DESCRIPTION
Testing ShellCheck CI with a purposely broken string. This should produce an [SC2086](https://www.shellcheck.net/wiki/SC2086) warning.