### PR TITLE
extProtonRun: Use 'printf "%q"' when parsing RUNPROGARGS

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240323-2 (extProtonRun-printf-q)"
+PROGVERS="v14.0.20240325-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240323-1 (extProtonRun-printf-q)"
+PROGVERS="v14.0.20240323-2 (extProtonRun-printf-q)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -7079,12 +7079,37 @@ function extProtonRun {
 		if [ -z "$PROGARGS" ] || [ "$PROGARGS" == "$NON" ]; then
 			RUNPROGARGS=""
 		else
-			mapfile -d " " -t -O "${#RUNPROGARGS[@]}" RUNPROGARGS < <(printf '%q' "$PROGARGS")
+			mapfile -d " " -t -O "${#TMP_RUNPROGARGS[@]}" TMP_RUNPROGARGS < <( printf "%q" "$PROGARGS" )
+
+			# Basically check for and join paths that contain spaces because above mapfile will strip them
+			# TODO: This does NOT work with paths that use forward slashes 
+			for i in "${!TMP_RUNPROGARGS[@]}"; do
+				# Remove trailing backslash, i.e. turn `--launch\` into `--launch`
+				TMP_RUNPROGARGS[i]="${TMP_RUNPROGARGS[i]%\\}"
+
+				# If the last seen element in the array ended with a backslash, assume
+				# this is an incomplete path and join them
+				#
+				# This is not perfect as valid paths that just end with backslashes will not work,
+				# but we can document this on the wiki
+				#
+				# i.e. "Z:\this\is\a\path\ MY_VAR=2" will not work, but "Z:\this\is\a\path MY_VAR=2" will work
+				if [[ $LASTRUNPROGARG = *"\\" ]]; then
+					# Remove 'i-1' (previous element), because 'i' (current element) will contain 'i-1'
+					unset "TMP_RUNPROGARGS[i-1]"
+					TMP_RUNPROGARGS[i]="${LASTRUNPROGARG} ${TMP_RUNPROGARGS[i]}"        
+				fi
+				LASTRUNPROGARG="${TMP_RUNPROGARGS[i]}"
+			done
+
+			# Generate new array with null strings removed.
+			mapfile -t -O "${#RUNPROGARGS[@]}" RUNPROGARGS < <( printf "%s\n" "${TMP_RUNPROGARGS[@]}" | grep -v "^$" )
 		fi
 
 		FWAIT=2
 
 		# mirrors above RUNPROGARGS
+		# TODO what if we try to pass paths with spaces? This could be problematic here...
 		if [ -z "$EXTPROGRAMARGS" ]; then
 			writelog "INFO" "${FUNCNAME[0]} - No external program args here it seems"
 			RUNEXTPROGRAMARGS=( "" )

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240323-1"
+PROGVERS="v14.0.20240323-1 (extProtonRun-printf-q)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -7079,7 +7079,7 @@ function extProtonRun {
 		if [ -z "$PROGARGS" ] || [ "$PROGARGS" == "$NON" ]; then
 			RUNPROGARGS=""
 		else
-			mapfile -d " " -t -O "${#RUNPROGARGS[@]}" RUNPROGARGS < <(printf '%s' "$PROGARGS")
+			mapfile -d " " -t -O "${#RUNPROGARGS[@]}" RUNPROGARGS < <(printf '%q' "$PROGARGS")
 		fi
 
 		FWAIT=2


### PR DESCRIPTION
Partial fix for #1072.
See also #1074.

When parsing `PROGARGS` in `extProtonRun`, we just use `printf "%s"`. However it seems we need to double-escape paths with backslashes when giving them to executables. This is probably because we cannot preserve quotes in these paths, so the `\` is read as an escape character and not a literal `\`.

We can use `printf "%q"` to actually escape these paths, turning a path with single backslashes into `Z:\\home\\gaben\\Games\\Half-Life 3\\hl3.exe`.

Manually setting any paths in `CUSTOMCMD_ARGS` to use double-backslashes like above will actually fix it (needs a quadruple escape from the Yad GUI). So hopefully, using `"%q"` here will do this automatically. This would mean we can store `CUSTOMCMD_ARGS` with single backslashes, and then `extProtonRun` will properly handle the backslash paths.

Note that saving paths with single backslashes from the Game Menu is currently broken. You will need to double-escape *on each save*, because they are escaped on each load of the Game Menu and thus on each save are escaped back. #1074 fixes the saving part, which means custom command arguments with single backslashes passed on the Game Menu will work with this PR.

<hr>

Since posting this PR, a change was made to fix an issue caused by `printf "%q"` appending a stray `\` to launch flags with a space. This is mentioned briefly in the first comment on this PR (https://github.com/sonic2kk/steamtinkerlaunch/pull/1073#issuecomment-2016356921).

Please see https://github.com/sonic2kk/steamtinkerlaunch/issues/1072#issuecomment-2016349422 for more details and background on the fix for paths with spaces.