### PR TITLE
Menus: Display paths with backslashes properly

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240322-1 (customcmd-args-backslash-fix)"
+PROGVERS="v14.0.20240323-1 (customcmd-args-backslash-fix)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -6437,7 +6437,7 @@ function MainMenu {
 			SETHEAD="$SETHEAD \n<b>${GUI_SGA}:</b> Origin $L2EA url"
 		else
 			if [ "${#ORGCMDARGS[@]}" -ge 1 ]; then
-				SETHEAD="$SETHEAD \n<b>${GUI_SGA}:</b> ${ORGCMDARGS[*]}"
+				SETHEAD="$( printf "%s \n<b>%s</b> %q" "${SETHEAD}" "${GUI_SGA}" "${ORGCMDARGS[*]}" )"
 			fi
 		fi
 	fi

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240320-2"
+PROGVERS="v14.0.20240322-1 (customcmd-args-backslash-fix)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -5652,7 +5652,7 @@ function AllSettingsEntriesDummyFunction {
 --field="     $GUI_KEEPSTLOPEN!$DESC_KEEPSTLOPEN ('KEEPSTLOPEN')":CHK "${KEEPSTLOPEN/#-/ -}" `#CAT_Misc` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_USECUSTOMCMD!$DESC_USECUSTOMCMD ('USECUSTOMCMD')":CHK "${USECUSTOMCMD/#-/ -}" `#CAT_Misc` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_CUSTOMCMD!$DESC_CUSTOMCMD $GUI_ECHOPLAC ('CUSTOMCMD')":FL "${OPCUSTPATH/#-/ -}" `#CAT_Misc` `#MENU_GAME` \
---field="     $GUI_CUSTOMCMD_ARGS!$DESC_CUSTOMCMD_ARGS ('CUSTOMCMD_ARGS')" "${CUSTOMCMD_ARGS/#-/ -}" `#CAT_Misc` `#MENU_GAME` \
+--field="     $GUI_CUSTOMCMD_ARGS!$DESC_CUSTOMCMD_ARGS ('CUSTOMCMD_ARGS')" "$( printf "%s" "${CUSTOMCMD_ARGS/#-/ -}" )" `#CAT_Misc` `#MENU_GAME` \
 --field="     $GUI_FORK_CUSTOMCMD!$DESC_FORK_CUSTOMCMD ('FORK_CUSTOMCMD')":CHK "${FORK_CUSTOMCMD/#-/ -}" `#CAT_Misc` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_EXTPROGS_CUSTOMCMD!$DESC_EXTPROGS_CUSTOMCMD ('EXTPROGS_CUSTOMCMD')":CHK "${EXTPROGS_CUSTOMCMD/#-/ -}" `#CAT_Misc` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_ONLY_CUSTOMCMD!$DESC_ONLY_CUSTOMCMD ('ONLY_CUSTOMCMD')":CHK "${ONLY_CUSTOMCMD/#-/ -}" `#CAT_Misc` `#SUB_Checkbox` `#MENU_GAME` \

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240323-1 (customcmd-args-backslash-fix)"
+PROGVERS="v14.0.20240323-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"


### PR DESCRIPTION
Partial fix for #1072.
See also: #1073.

## Overview
On various places on the UI, we may display paths with backslashes. This PR is concerned with those paths coming from the Steam Game Launch Options, and the Custom Command arguments, and fixes them by using `printf` in various ways.

## Problem
The problems are as follows:
- **Game Menu**
    - Entering a path with backslashes in a custom command argument, such as `Z:\this\is\my\path`, and then saving, will strip this path of its backslashes, turning it into `Z:\thisismypath`.
    - This can be worked around by double escaping, but the path would then turn out like this: `Z:\\this\\is\\my\\path` -> Save -> Path becomes `Z:\this\is\my\path` -> Save again -> `Z:thisismypath` - This is because the path is getting stripped of backslashes from the escaping on each save
    - This means each time the Game Menu is opened, paths with backslashes need to be quadruple-escaped before saving.
- **Main Menu**
    - Paths coming from Steam with backslashes (with and without quotes) will not display their backslashes properly.
    - Ex: This launch option `Z:\this\is\my\path` will be displayed on the SteamTinkerLaunch Main Menu as `Z:thisismypath`.

## Solution
This PR fixes these problems in two different ways, both using `printf`:
- For the Game Menu, we can use `printf "%s"` in a subshell when displaying the field for `CUSTOMCMD_ARGS`. This, for some reason I don't fully understand, fixes displaying and thus saving the paths with backslashes correctly. They are no longer mangled.
- For the Main Menu, we can use `printf "%q"`, which is an option that preserves strings to be used as part of a command. This handles our double-escaping for display purposes
    - We cannot use `%q` for the Game Menu because then the double-escapes (and the escape around any other parts of the launch command) would be displayed, which would also result in the commands not launching correctly.

Note that paths going as arguments to custom commands may need to be double-escaped, as they don't have quotes. This PR corrects the display and saving of these paths, and #1073 fixes the paths so that they are double-escaped.

Fwiw, Proton doesn't seem to get quotes for launch arguments either though (https://github.com/sonic2kk/steamtinkerlaunch/issues/1072#issuecomment-2016276706) so I think this is acceptable.