### PR TITLE
CI: Run ShellCheck on all pushes and all PRs

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,11 +1,8 @@
 on:
   push:
-    branches:
-      - master
     paths:
       - 'steamtinkerlaunch'
   pull_request:
-    types: [ labeled ]
     paths:
       - 'steamtinkerlaunch'
 
@@ -14,8 +11,7 @@ permissions: {}
 
 jobs:
   shellcheck:
-    if: ${{ (github.event_name == 'pull_request' && github.event.label.name == 'shellcheck') || (github.event_name == 'push' && github.ref == 'refs/heads/master') }}
-    name: Shellcheck
+    name: ShellCheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -19,4 +19,3 @@ jobs:
         uses: ludeeus/action-shellcheck@master
         with:
           version: v0.10.0
-          SHELLCHECK_OPTS: --extended-analysis=false


### PR DESCRIPTION
Changes the CI to run ShellCheck on the `steamtinkerlaunch` file on all pushes to all branches. It should also run it whenever a PR is opened, although I'm not sure how that one works! 

Since public projects using GitHub Hosted runners don't get charged minutes, we should be safe to do this.