### PR TITLE
updateConfigEntry: Pass `sed` an escaped `CFGVALUE`

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240324-1 (updateConfigEntry-escpae-incoming-cfgvalue)"
+PROGVERS="v14.0.20240324-2 (updateConfigEntry-escpae-incoming-cfgvalue)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -10921,7 +10921,6 @@ function createDefaultCfgs {
 function updateConfigEntry {
 	CFGCAT="$1"
 	CFGVALUE="$2"
-	ESCAPED_CFGVALUE="$( printf "%s" "$CFGVALUE" | sed 's/\\/\\\\/g' )"  # Help prevent expanding incoming config values by escaping them (i.e. when using with sed)
 	CFGFILE="$3"
 
 	if [ "$CFGCAT" == "CUSTOMCMD" ] && [ "$CFGFILE" == "$STLDEFGAMECFG" ]; then
@@ -10945,6 +10944,9 @@ function updateConfigEntry {
 				if [ "$CFGVALUE" == "DUMMY" ]; then
 					CFGVALUE=""
 				fi
+
+				# Help prevent expanding incoming config values by escaping them (i.e. when using with sed)
+				ESCAPED_CFGVALUE="$( printf "%s\n" "$CFGVALUE" | sed 's/\\/\\\\/g' )"
 
 				# only save value if it changed
 				# sed needs escaped string because otherwise it'll expand escape sequences in strings with backslashes

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240324-2 (updateConfigEntry-escpae-incoming-cfgvalue)"
+PROGVERS="v14.0.20240325-2 (updateConfigEntry-escpae-incoming-cfgvalue)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240325-2 (updateConfigEntry-escpae-incoming-cfgvalue)"
+PROGVERS="v14.0.20240325-2"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240325-1"
+PROGVERS="v14.0.20240324-1 (updateConfigEntry-escpae-incoming-cfgvalue)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -10921,6 +10921,7 @@ function createDefaultCfgs {
 function updateConfigEntry {
 	CFGCAT="$1"
 	CFGVALUE="$2"
+	ESCAPED_CFGVALUE="$( printf "%s" "$CFGVALUE" | sed 's/\\/\\\\/g' )"  # Help prevent expanding incoming config values by escaping them (i.e. when using with sed)
 	CFGFILE="$3"
 
 	if [ "$CFGCAT" == "CUSTOMCMD" ] && [ "$CFGFILE" == "$STLDEFGAMECFG" ]; then
@@ -10946,17 +10947,20 @@ function updateConfigEntry {
 				fi
 
 				# only save value if it changed
+				# sed needs escaped string because otherwise it'll expand escape sequences in strings with backslashes
+				# i.e. config values with Windows paths, '\home\test' will have '\t' expanded as a tab character
+				# We have to use the regular one for echo though.
 				if { [ "${!CFGCAT}" != "$CFGVALUE" ] && [ "${!CFGCAT}" != "${CFGVALUE//$STLCFGDIR/STLCFGDIR}" ];} || [ -f "$FUPDATE" ]; then
 					CFGVALUE="${CFGVALUE//$STLCFGDIR/STLCFGDIR}"
 					if [ "$(grep -c "#${CFGCAT}=" "$CFGFILE")" -eq 1 ]; then
 						writelog "INFO" "${FUNCNAME[0]} - Option '$CFGCAT' commented out in config '${CFGFILE##*/}' - activating it with the new value '$CFGVALUE'"
-						sed -i "/^#${CFGCAT}=/c$CFGCAT=\"$CFGVALUE\"" "$CFGFILE"
+						sed -i "/^#${CFGCAT}=/c$CFGCAT=\"$ESCAPED_CFGVALUE\"" "$CFGFILE"
 					elif [ "$(grep -c "^${CFGCAT}=" "$CFGFILE")" -eq 0 ]; then
 						writelog "INFO" "${FUNCNAME[0]} - '$CFGCAT' option missing in config '${CFGFILE##*/}' - adding a new line"
 						echo "$CFGCAT=\"$CFGVALUE\"" >> "$CFGFILE"
 					else
 						writelog "INFO" "${FUNCNAME[0]} - Option '$CFGCAT' is updated with the new value '$CFGVALUE' in config '${CFGFILE##*/}'"
-						sed -i "/^${CFGCAT}=/c$CFGCAT=\"$CFGVALUE\"" "$CFGFILE"
+						sed -i "/^${CFGCAT}=/c$CFGCAT=\"$ESCAPED_CFGVALUE\"" "$CFGFILE"
 					fi
 					rm "$FUPDATE" 2>/dev/null
 				fi


### PR DESCRIPTION
Work for #1072.

`sed` will expand escape sequences in strings, so give it an escaped version of the `CFGVALUE` string to make updating existing config value items with backslashes work without expanding them. For example, `sed` would escape the following string, removing all backslashes and expanding the `\t` to be a tab character: `Z:\home\gaben\testgames`.

Should fix updating blank config entry items to have new values with backslashes in them. For example, updating a blank `CUSTOMCMD_ARGS` to have `CUSTOMCMD_ARGS="Z:\home\gaben\testgames"`.