### PR TITLE
Misc: Bump Yad AppImage to use new release

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240526-3"
+PROGVERS="v14.0.20240324-1 (bump-yad-appimage)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -18197,7 +18197,8 @@ function setYadBin {
 		fi
 
 	elif [ "$1" == "ai" ] || [ "$1" == "appimage" ]; then
-		YADSTLIMAGE="Yad-8418e37-x86_64.AppImage"
+		# YADSTLIMAGE="Yad-8418e37-x86_64.AppImage"
+		YADSTLIMAGE="Yad-fbfb0fa-x86_64.AppImage"
 		YAIDL="$YAIURL/$YADSTLIMAGE/$YADSTLIMAGE"
 		YADAPPIMAGE="$YADSTLIMAGE"
 		DLCHK="sha512sum"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -18198,7 +18198,7 @@ function setYadBin {
 
 	elif [ "$1" == "ai" ] || [ "$1" == "appimage" ]; then
 		# YADSTLIMAGE="Yad-8418e37-x86_64.AppImage"
-		YADSTLIMAGE="Yad-fbfb0fa-x86_64.AppImage"
+		YADSTLIMAGE="Yad-13.0-x86_64.AppImage"
 		YAIDL="$YAIURL/$YADSTLIMAGE/$YADSTLIMAGE"
 		YADAPPIMAGE="$YADSTLIMAGE"
 		DLCHK="sha512sum"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240324-1 (bump-yad-appimage)"
+PROGVERS="v14.0.20240325-3 (bump-yad-appimage)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -18223,7 +18223,6 @@ function setYadBin {
 				export ONSTEAMDECK=1
 				YADAIDLDIR="$STLSDPATH"
 				YAIDST="$YADAIDLDIR/$YADAPPIMAGE"
-				YAIURL="$GHURL/sonic2kk/steamtinkerlaunch-tweaks/releases/download"  # TODO isn't this already defined in URLs with the same namd and path?
 				YAIDL="$YAIURL/$YADSTLIMAGE/$YADSTLIMAGE"
 				YADAPPIMAGE="$YADSTLIMAGE"
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240526-4 (bump-yad-appimage)"
+PROGVERS="v14.0.20240529-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240325-3 (bump-yad-appimage)"
+PROGVERS="v14.0.20240526-4 (bump-yad-appimage)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"


### PR DESCRIPTION
Implements #1060.
Related #859.

Bump Yad AppImage to use new release over at: https://github.com/sonic2kk/steamtinkerlaunch-tweaks/releases/tag/Yad-fbfb0fa-x86_64.AppImage

We pin to the latest AppImage release on GitHub by assuming the release name and AppImage will have the same string. The new release should follow this convention. This means existing code and older releases will still use the old AppImage, but newer versions will download the new AppImage.

This new release updates the Yad version. As always on SteamOS, dependencies will have to be cleared to test this (the `steamtinkerlaunch cleardeckdeps` command).

This PR needs significant amounts of testing before it can be merged. Once merged, the AppImage release will no longer be marked as a draft.