### PR TITLE
ReShade: Use `ALTEXEPATH` to install ReShade DLLs for Custom Commands with `ONLY_CUSTOMCMD=1`

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240421-1"
+PROGVERS="v14.0.20240421-1 (fix-reshade-dlls-custcmd)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -9582,7 +9582,9 @@ function installRSdll {
 function installReshade {
 	if [ "$USERESHADE" -eq 1 ]; then
 		prepareReshadeFiles
-		setShadDestDir
+		# setShadDestDir
+		# Use setShaderDest to avoid overwriting ALTEXEPATH if defined
+		setShaderDest
 
 		INSTDESTDIR="$SHADDESTDIR"
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -9132,8 +9132,10 @@ function ShaderRepoDialog {
 
 function setFullGameExePath {
 	if [[ ( "$USECUSTOMCMD" -eq 1 && -f "$CUSTOMCMD" && "$CUSTOMCMDRESHADE" -eq 1 ) || "$ONLY_CUSTOMCMD" -eq 1 ]]; then
-		FGEP="${CUSTOMCMD%/*}"
-
+		# Use Alternative EXE Path if defined instead of custom command path
+		# We should only use the custom command directory if no alternatiive EXE path is defined, and
+		# we should prioritise the alt path if it is defined
+		FGEP="${DEFINEDALTEXEPATH:-${CUSTOMCMD%/*}}"
 		writelog "INFO" "${FUNCNAME[0]} - Using the directory '$FGEP' of the used custom command as absolute game exe path"
 
 		if [ "$CUSTOMCMDRESHADE" -eq 1 ]; then
@@ -9582,9 +9584,7 @@ function installRSdll {
 function installReshade {
 	if [ "$USERESHADE" -eq 1 ]; then
 		prepareReshadeFiles
-		# setShadDestDir
-		# Use setShaderDest to avoid overwriting ALTEXEPATH if defined
-		setShaderDest
+		setShadDestDir  # Have to use setShadDestDir because setShadDest will use ABSGAMEEXEPATH which is not Custom Command 
 
 		INSTDESTDIR="$SHADDESTDIR"
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240421-1 (fix-reshade-dlls-custcmd)"
+PROGVERS="v14.0.20240421-2 (fix-reshade-dlls-custcmd)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -9135,6 +9135,7 @@ function setFullGameExePath {
 		# Use Alternative EXE Path if defined instead of custom command path
 		# We should only use the custom command directory if no alternatiive EXE path is defined, and
 		# we should prioritise the alt path if it is defined
+		DEFINEDALTEXEPATH="$(GETALTEXEPATH)"
 		FGEP="${DEFINEDALTEXEPATH:-${CUSTOMCMD%/*}}"
 		writelog "INFO" "${FUNCNAME[0]} - Using the directory '$FGEP' of the used custom command as absolute game exe path"
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240421-2 (fix-reshade-dlls-custcmd)"
+PROGVERS="v14.0.20240423-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"


### PR DESCRIPTION
Fixes #1089.

This PR adds an extra check to `setFullGameExePath`, where if an alternative EXE path is defined, this should be used in place of the custom command EXE directory. This makes sense to me, as the order of priority should be to use `ALTEXEPATH` above all other paths when deciding where to put things, and otherwise either the custom command folder (if custom commands are enabled) or the game EXE folder should be used.

This should address an issue where when installing ReShade with `ONLY_CUSTOMCMD` enabled, ReShade would install shaders to the ALTEXEPATH (as this is handled by `setShadDest`) but it would not do this for the ReShade DLLs - handled by a call in `installReshade` to `setShadDestDir`, which in turn calls `setFullGameExePath` to get the path where the DLLs should be installed.

This will need some testing to ensure this doesn't cause any regressions. The following cases should be testing:
- [x] Regular game launches should still work fine
- [x] Regular game launches with an Alt EXE dir should respect the chosen alt EXE path
- [x] Custom commands with alt EXE paths chosen should respect it with ReShade
- [x] Custom commands with alt EXE paths chosen should respect it without ReShade