### PR TITLE
fix: update mo2 'getprefix' arg to match help docs

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -22581,7 +22581,7 @@ function commandline {
 					writelog "INFO" "${FUNCNAME[0]} - URL passed is '$3'"
 					dlMod2nexurl "$3"
 				fi
-			elif [ "$2" == "getpfx" ] || [ "$2" == "gp" ]; then
+			elif [ "$2" == "getprefix" ] || [ "$2" == "gp" ]; then
 				echo "$MO2COMPDATA/pfx"
 			elif [ "$2" == "repairpfx" ]; then
 				setMO2Vars


### PR DESCRIPTION

Small fix to change the `mo2` `getpfx` option to `mo2` `getprefix`, which matches what's in the howto/help docs.  

I chose this route over updating the docs since it matched the `vortex` `getprefix|gp` args, but feel free to change it.

## Testing (before)
Show that the howto/help docs list `mo2`  `getprefix|gp` options. (this PR doesn't change this)
```sh
$ steamtinkerlaunch --help | grep -A 3 " mo2"
    mo2                              Mod Organizer 2
         create-instance|ci <id>     create MO2 instance for <id>
         download|d                  download latest MO2 release
         getprefix|gp                Output path to MO2 prefix
```

Using `steamtinkerlaunch mo2 getprefix` displays the howto/help docs
```sh
$ steamtinkerlaunch mo2 gp
/home/user/.config/steamtinkerlaunch/mo2/compatdata/pfx

$ steamtinkerlaunch mo2 getprefix | head -n 4
=========================
SteamTinkerLaunch v14.0.20240423-1
=========================
Usage: steamtinkerlaunch [options]...
```

## Testing (after)
Using `steamtinkerlaunch mo2 getprefix` matches the `mo2 gp` output.
```sh
$ steamtinkerlaunch mo2 gp
/home/user/.config/steamtinkerlaunch/mo2/compatdata/pfx

$ steamtinkerlaunch mo2 getprefix
/home/user/.config/steamtinkerlaunch/mo2/compatdata/pfx
```
