### PR TITLE
trim Proton beta and rc versioning (fixes #1094)

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240330-1"
+PROGVERS="v14.0.20240503-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -13338,7 +13338,9 @@ function redirectSCDP {
 
 	## There is room for improvement here, community contributions welcome!
 	if [ -n "$STEAM_COMPAT_DATA_PATH" ]; then # should be enough
-		VERSPROTMAJOR="${USEPROTON%-*}"  # Turns Proton name from "proton-8.0-3c" to "proton-8.0"
+		VERSPROTMAJOR="$( printf '%s' "${USEPROTON}" | sed -e 's/-\(rc\|beta\)[0-9]\+$//' \
+															-e 's/-[0-9A-Za-z_]\+$//' )"
+		# Above first removes -beta# and -rc# from Proton names. Then turns the Proton name from "proton-8.0-3c" to "proton-8.0"
 		VERSFIX="$(grep "${PROTVERSNOMINOR}" "$PROTONCSV" | cut -d ';' -f1 | sort -nr | head -n1)"
 
 		if [ "${ONLYPROTMAJORREDIRECT}" -eq 1 ]; then  # Only create redirect folders for major Proton version bumps, such as GE-Proton7 -> GE-Proton8, or Proton 7.0 -> Proton 8.0 (IGNORING minor fix versions)


### PR DESCRIPTION
When ONLYPROTMAJORREDIRECT is enabled, beta and release candidate versioning will not be included in new Proton compatdata names.