### PR TITLE
Custom Command: Launch .lnk files using Proton automatiically

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240512-2"
+PROGVERS="v14.0.20240516-1 (customcmd-lnk-files)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -12737,8 +12737,9 @@ function launchCustomProg {
 			writelog "INFO" "${FUNCNAME[0]} - Generated arguments for custom command are now '${FINALOUTCMD[*]}'"
 		fi
 
+		# Use Wine/Proton with a custom command if it is detected as a Windows executable, a batch script (.bat), a Windows shortcut (.lnk), or if the user forces Proton
 		# Cannot always rely on `file` to return `PE32` even for Windows executables -- See #710 (seems to be when exe files are built on Linux they are not PE32)
-		if [ "$(file "$CUSTCOM" | grep -c "PE32")" -eq 1 ] || grep -q ".bat" <<< "$CUSTCOM" || [ "$CUSTOMCMDFORCEWIN" -eq 1 ]; then
+		if [ "$(file "$CUSTCOM" | grep -c "PE32")" -eq 1 ] || grep -q ".bat" <<< "$CUSTCOM" || grep -q ".lnk" <<< "$CUSTCOM" || [ "$CUSTOMCMDFORCEWIN" -eq 1 ]; then
 			if [ "$CUSTOMCMDFORCEWIN" -eq 1 ]; then
 				# Force custom command to use Wine/Proton, even if we do not detect it as a valid Windows binary
 				writelog "INFO" "${FUNCNAME[0]} - CUSTOMCMDFORCEWIN is '$CUSTOMCMDFORCEWIN' - User wants to force this custom command as a Windows program"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240516-1 (customcmd-lnk-files)"
+PROGVERS="v14.0.20240526-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"


### PR DESCRIPTION
When trying to use `.lnk` files as custom commands, SteamTinkerLaunch will default to interpreting these as native games, because it does not return the `PE32` string from "Files" and it is not a `.bat` script. Since this is not a native program it will try to run this with whatever program is set up on the system to handle files of this type. Commonly this is Wine but if a user doesn't have Wine installed it could end up opening a text editor, a hex editor, or anything really.

As a workaround it is possible to force Proton since 77e07727f9463da19b65164d57a410c211b14eb2 (no PR for this one apparently). But this is not ideal.

To fix this, we check if the custom command ends with `.lnk` and if so we catch this as a custom command to run with Proton. I tested this with Touhou 16 and it fixed the problem. Without this PR it tries to use the system Wine to run the file.

We could've used `file` here to check for `MS Windows shortcut` but I opted to check the extension for simplicity and just in case this ever returns a different string (`PE32` is universal and virtually guaranteed to never change). This isn't perfect because if a filename has `.lnk` anywhere we'll try to use Proton even if it's not a Windows shortcut. But we do the exact same check for `.bat` files and it could have the exact same pitfalls, but that has not yet been reported.

If either of these ever become issues though we can use a different pattern to match the end of the string with the extension.

NOTE: Custom commands do not use the Steam Linux Runtime, but maybe this will change in the near future, as I've run into a few cases recently where I want to use custom commands to replace a game launch, and the lack of SLR has caused issues.

TOD:
- [ ] Further testing to ensure regular custom commands (native and Proton) still work
- [ ] Version bump