### PR TITLE
Non-Steam Game: Add `non-steam|nsg` filter to `list` Command

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7779,8 +7779,8 @@ function pickGameWindowNameMeta {
 
 # General function for the "steamtinkerlaunch list <arg> function"
 # Can take two types of commands:
-# - `steamtinkerlaunch list owned/installed` - Returns "Game Name (AppID)"
-# - `steamtinkerlaunch list owned/installed id/name/path/full` - Returns either AppID, Game Name, Game Paths, or all in the format "Game Name (AppID) -> /path/to/game"
+# - `steamtinkerlaunch list owned/installed/non-steam` - Returns "Game Name (AppID)"
+# - `steamtinkerlaunch list owned/installed/non-steam id/name/path/full` - Returns either AppID, Game Name, Game Paths, or all in the format "Game Name (AppID) -> /path/to/game"
 #
 # This function is not very efficient, Non-Steam Games in particular are inefficient because we read shortcuts.vdf each time we want to parse info
 # We parse it once to get the IDs, then again in each `getTitleFromID` and `getGameDir` call. This makes it pretty slow
@@ -7849,7 +7849,7 @@ function listSteamGames {
 			done
 		fi
 	elif [ "$LSTYPE" == "count" ]; then
-		printf "\n%s" "$( getGameCount )"
+		printf "\n%s\n" "$( getGameCount )"
 	elif [ "$LSTYPE" == "full" ] || [ -z "$LSTYPE" ]; then  # This is the default if id/name/path/full is not passed
 		for AID in "${LISTAIDSARR[@]}"; do
 			GAMDIR="$( getGameDir "$AID" "" "${SEARCHSTEAMSHORTCUTS}" )"
@@ -22194,7 +22194,7 @@ function howto {
 	echo "             auto                      Create/Download data for all installed games first"
 	echo "             update                    ReCreate all Collection Menus"
 	echo "                                       Can be combined with auto"
-	echo "    list <owned|installed>           List ids of <owned|o,installed|i> games"
+	echo "    list <owned|installed|non-steam>   List info on <owned|o,installed|i,non-steam|nsg> games"
 	echo "         <id|name|path|count|full>     Optionally specify whether you want to see"
 	echo "                                        each game's <id|name|path|count|full>"
 	echo "    listproton|lp                    List name and path of all Proton versions known to SteamTinkerLaunch"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240608-1"
+PROGVERS="v14.0.20240608-2 (list-all-nonsteam-games)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -7781,78 +7781,96 @@ function pickGameWindowNameMeta {
 # Can take two types of commands:
 # - `steamtinkerlaunch list owned/installed` - Returns "Game Name (AppID)"
 # - `steamtinkerlaunch list owned/installed id/name/path/full` - Returns either AppID, Game Name, Game Paths, or all in the format "Game Name (AppID) -> /path/to/game"
+#
+# This function is not very efficient, Non-Steam Games in particular are inefficient because we read shortcuts.vdf each time we want to parse info
+# We parse it once to get the IDs, then again in each `getTitleFromID` and `getGameDir` call. This makes it pretty slow
+# It works for now, but in future we should enhance it
 function listSteamGames {
 	function getGameCount {
+		TOTALGAMESOWNEDPRINTFSTR=""
+
 		if [ "$LSFILTER" == "owned" ] || [ "$LSFILTER" == "o" ]; then
-			printf "Total games owned: %s\n" "${#LISTAIDSARR[@]}"
+			TOTALGAMESOWNEDPRINTFSTR="Total games owned"
+		elif [ "$LSFILTER" == "non-steam" ] || [ "$LSFILTER" == "nsg" ]; then
+			TOTALGAMESOWNEDPRINTFSTR="Total Non-Steam Games in library"
 		else
-			printf "Total games installed: %s\n" "${#LISTAIDSARR[@]}"
+			TOTALGAMESOWNEDPRINTFSTR="Total games installed"
 		fi
+
+		printf "${TOTALGAMESOWNEDPRINTFSTR}: %s\n" "${#LISTAIDSARR[@]}"
 	}
 
-	LSFILTER="$1"  # e.g. "owned", "installed"
+	LSFILTER="$1"  # e.g. "owned", "installed", "non-steam"
 	LSTYPE="$2"  # e.g. "id", "name", "path", "count", "full"
 	LISTAIDS=""
+
+	SEARCHSTEAMSHORTCUTS="0"
 
 	if [ "$LSFILTER" == "owned" ] || [ "$LSFILTER" == "o" ]; then
 		LISTAIDS="$( getOwnedAids )"
 	elif [ "$LSFILTER" == "installed" ] || [ "$LSFILTER" == "i" ]; then
-		if [ "$(listInstalledGameIDs | wc -l)" -eq 0 ]; then
-			writelog "SKIP" "${FUNCNAME[0]} - No installed games found!" "E"
-			echo "No installed games found!"
+		LISTAIDS="$( listInstalledGameIDs )"
+	elif [ "$LSFILTER" == "non-steam" ] || [ "$LSFILTER" == "nsg" ]; then
+		LISTAIDS="$( listNonSteamGameIDs )"
+		SEARCHSTEAMSHORTCUTS="1"  # Only search Steam Shortcuts if we passed that filter type
+	else
+		writelog "INFO" "${FUNCNAME[0]} - Unknown argument passed to 'list' command - '$LSFILTER'"
+		echo "unknown argument passed to 'list' command - '$LSFILTER'"
+
+		exit
+	fi
+
+	if [ -z "$LISTAIDS" ]; then
+		writelog "SKIP" "${FUNCNAME[0]} - No games found for given filter '$LSFILTER'"
+		echo "No games found for filter '$LSFILTER'."
+
+		exit
+	fi
+
+	readarray -t LISTAIDSARR <<<"$LISTAIDS"
+
+	if [ "$LSTYPE" == "id" ]; then
+		for AID in "${LISTAIDSARR[@]}"; do
+			echo "$AID"
+		done
+	elif [ "$LSTYPE" == "name" ]; then
+		for AID in "${LISTAIDSARR[@]}"; do
+			getTitleFromID "${AID}" "${SEARCHSTEAMSHORTCUTS}"
+		done
+	elif [ "$LSTYPE" == "path" ]; then
+		if [ "$LSFILTER" == "owned" ] || [ "$LSFILTER" == "o" ]; then
+			echo "Cannot use 'path' option when returning 'owned' games, as not all owned games will have an installation path!"
+			echo "Use another option instead, or leave blank to only return path for games which have an installation path."
 
 			exit
 		else
-			LISTAIDS="$( listInstalledGameIDs )"
+			for AID in "${LISTAIDSARR[@]}"; do
+				getGameDir "$AID" "1" "${SEARCHSTEAMSHORTCUTS}"
+			done
 		fi
-	else
-		echo "unknown argument passed to 'list' command - '$LSFILTER'"
-	fi
+	elif [ "$LSTYPE" == "count" ]; then
+		printf "\n%s" "$( getGameCount )"
+	elif [ "$LSTYPE" == "full" ] || [ -z "$LSTYPE" ]; then  # This is the default if id/name/path/full is not passed
+		for AID in "${LISTAIDSARR[@]}"; do
+			GAMDIR="$( getGameDir "$AID" "" "${SEARCHSTEAMSHORTCUTS}" )"
+			GAMDIREXISTS=$?
 
-	if [ -n "$LISTAIDS" ]; then
-		readarray -t LISTAIDSARR <<<"$LISTAIDS"
-
-		if [ "$LSTYPE" == "id" ]; then
-			for AID in "${LISTAIDSARR[@]}"; do
-				echo "$AID"
-			done
-		elif [ "$LSTYPE" == "name" ]; then
-			for AID in "${LISTAIDSARR[@]}"; do
-				getTitleFromID "${AID}"
-			done
-		elif [ "$LSTYPE" == "path" ]; then
-			if [ "$LSFILTER" == "owned" ] || [ "$LSFILTER" == "o" ]; then
-				echo "Cannot use 'path' option when returning 'owned' games, as not all owned games will have an installation path!"
-				echo "Use another option instead, or leave blank to only return path for games which have an installation path."
-			else
-				for AID in "${LISTAIDSARR[@]}"; do
-					getGameDir "$AID" "1"
-				done
-			fi
-		elif [ "$LSTYPE" == "count" ]; then
-			printf "\n%s" "$( getGameCount )"
-		elif [ "$LSTYPE" == "full" ] || [ -z "$LSTYPE" ]; then  # This is the default if id/name/path/full is not passed
-			for AID in "${LISTAIDSARR[@]}"; do
-				GAMDIR="$( getGameDir "$AID" )"
-				GAMDIREXISTS=$?
-
-				# Only display game dir if the game is installed, i.e. if getGameDir does not return 1
-				# This means we won't return an error if we're returning OWNED games, as some owned games may not have paths
-				if [ "$GAMDIREXISTS" -eq 1 ]; then
-					GAMNAM="$( getTitleFromID "$AID" )"
-					GAMNAMEXISTS=$?
-					if [ "$GAMNAMEXISTS" -eq 1 ]; then
-						echo "$AID"  # Game name unknown, probably never installed before? Just return AppID in this case
-					else
-						echo "$GAMNAM ($AID)"
-					fi
+			# Only display game dir if the game is installed, i.e. if getGameDir does not return 1
+			# This means we won't return an error if we're returning OWNED games, as some owned games may not have paths
+			if [ "$GAMDIREXISTS" -eq 1 ]; then
+				GAMNAM="$( getTitleFromID "$AID" "${SEARCHSTEAMSHORTCUTS}" )"
+				GAMNAMEXISTS=$?
+				if [ "$GAMNAMEXISTS" -eq 1 ]; then
+					echo "$AID"  # Game name unknown, probably never installed before? Just return AppID in this case
 				else
-					echo "$GAMDIR"
+					echo "$GAMNAM ($AID)"
 				fi
-			done
+			else
+				echo "$GAMDIR"
+			fi
+		done
 
-			printf "\n%s" "$( getGameCount )"  # Show total for "full"
-		fi
+		printf "\n%s\n" "$( getGameCount )"  # Show total for "full"
 	fi
 }
 
@@ -8318,6 +8336,15 @@ function getSteamShortcutHex {
 function getSteamShortcutsVdfFileHex {
 	SCPATH="$STUIDPATH/config/$SCVDF"
 	xxd -p -c 0 "$SCPATH"
+}
+
+function listNonSteamGameIDs {
+	NONSTEAMGAMEAIDS=()
+
+	writelog "INFO" "${FUNCNAME[0]} - Reading all Non-Steam AppIDs from shortcuts.vdf"
+	while read -r SCVDFE; do
+		parseSteamShortcutEntryAppID "$SCVDFE"
+	done <<< "$( getSteamShortcutHex )"
 }
 
 function haveAnySteamShortcuts {

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240608-2 (list-all-nonsteam-games)"
+PROGVERS="v14.0.20240609-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -8342,8 +8342,6 @@ function getSteamShortcutsVdfFileHex {
 }
 
 function listNonSteamGameIDs {
-	NONSTEAMGAMEAIDS=()
-
 	writelog "INFO" "${FUNCNAME[0]} - Reading all Non-Steam AppIDs from shortcuts.vdf"
 	while read -r SCVDFE; do
 		parseSteamShortcutEntryAppID "$SCVDFE"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7785,6 +7785,9 @@ function pickGameWindowNameMeta {
 # This function is not very efficient, Non-Steam Games in particular are inefficient because we read shortcuts.vdf each time we want to parse info
 # We parse it once to get the IDs, then again in each `getTitleFromID` and `getGameDir` call. This makes it pretty slow
 # It works for now, but in future we should enhance it
+#
+# One potential way to enhance this function is to split it out into a separate function for each filter type, but we would need
+# to consider how this function is used by other parts of the codebase and if that could be disruptive.
 function listSteamGames {
 	function getGameCount {
 		TOTALGAMESOWNEDPRINTFSTR=""
@@ -22187,7 +22190,7 @@ function howto {
 	echo "                                      Note that this will not remove your mods or installed Winetricks"
 	echo "    lang=<option>                    Mostly to get translated configs on inital setup."
 	echo "                                      <option> can be a language file name without suffix or an path to a valid language file"
- 	echo "    launcher <args>                  Start the Game Launcher"
+    echo "    launcher <args>                  Start the Game Launcher"
 	echo "             COLLECTION                Show only installed games from Steam collection COLLECTION"
 	echo "             menu                      Open Steam Collection Menu"
 	echo "             last                      Open last Game as 'Menu'"
@@ -22197,6 +22200,8 @@ function howto {
 	echo "    list <owned|installed|non-steam>   List info on <owned|o,installed|i,non-steam|nsg> games"
 	echo "         <id|name|path|count|full>     Optionally specify whether you want to see"
 	echo "                                        each game's <id|name|path|count|full>"
+	echo "                                       NOTE: Non-Steam Games will NOT be included in <installed,owned>,"
+	echo "                                        they will only show up for <non-steam|nsg>"
 	echo "    listproton|lp                    List name and path of all Proton versions known to SteamTinkerLaunch"
 	echo "         name|n                        Only list the Proton version names"
 	echo "         path|p                        Only list paths to the Proton versions"


### PR DESCRIPTION
Work for #960.

## Overview
This PR adds a `non-steam` filter (with `nsg` shorthand) to the `steamtinkerlaunch list` command. Now all Non-Steam Games in the library can be listed with the `list` command as AppID, name, path, count, or all of the above.

The usage is exactly the same as it is for using `owned` (`o`) or `installed` (`i`), but now we can use `non-steam` (`nsg`) with this command too.

Non-Steam Games are NOT printed alongside owned/installed AppIDs, they are ONLY printed when the `non-steam`/`nsg` filter is used.

As an aside, this also fixes a small formatting bug where `printf` wasn't taking a newline properly, which resulted in some ugly output, and the function has been flattened slightly.

## Implementation
We follow the same pattern as we do for `installed` and `owned`, and start by getting all of the Non-Steam Game AppIDs and then storing this in an `LISTAIDSARR` array. To do this, we have a new function to get all Non-Steam AppIDs, named `listNonSteamGameIDs`. This prints each AppID parsed from `shortcuts.vdf` in a `while` read loop the same way we do for `getOwnedAids` and `listInstalledGameIDs`.

From there the rest of the program just falls through the rest of the logic that it already does for `installed` and `owned`.

The regular logic here calls `getTitleFromID` and `getGameDir`, however these two functions have separate parameters to know whether they should search for Non-Steam Games or not. This was implemented because these functions are used in the codebase in situations where Non-Steam Games should not be returned (such as for Vortex game detection checks). Therefore searching on Non-Steam Games is **disabled** by default.

Likewise, we don't want `installed`/`owned` to return Non-Steam Games, so we only want to have these functions return Non-Steam Games when we search for them.

In order to get these functions to only return the Non-Steam Game AppIDs when we search for Non-Steam Games, we have a conditional variable to control this. We only call `listNonSteamGameIDs` if we pass the `non-steam` and `nsg` filter, so if we do this, we set `SEARCHSTEAMSHORTCUTS` equal to `1`. It is `0` by default. This value is given to `getTitleFromID` and `getGameDir`, as they expect `0`/`1` values. This allows us to control when these calls return Non-Steam Games, allowing us to only return Non-Steam Games when we explicitly want to find them.

## Concerns
This implementation is not very efficient in particular for Non-Steam Games. We fetch the list of AppIDs by parsing `shortcuts.vdf`, and then we have to do this all over again for each call to `getTitleFromID` and `getGameDir`.

This is the most inefficient for the default, where we want to get name *and* path for Non-Steam Games. With how the function is currently implemented, I don't see a clean way to refactor this. We are probably best off making separate functions for listing owned, installed, and Non-Steam games at some point in the future, but it's overkill for now.

The performance hit is undesirable but acceptable _for now_ until I find time to re-evaluate `listSteamGames`. If people complain about it being slow, and something downstream depends on it being faster, refactoring will be prioritized.

<hr>

This PR has been tested and it seems to still work fine in my testing with `owned`, `installed`, and now `non-steam` with no regressions or issues.

This will probably be ready to merge soon, pending a version bump. This is one of the last remaining tasks for the Non-Steam Game integration overhaul!

TODO:
- [x] Check if wiki needs updated
- [x] Version bump