### PR TITLE
Logging: Improve access to log files

### DIFF
--- a/lang/chinese.txt
+++ b/lang/chinese.txt
@@ -1284,3 +1284,6 @@ GUI_IGNORECOMPATSLR="Ignore Native Linux Steam Linux Runtime from Compatibility 
 DESC_IGNORECOMPATSLR="ignore Steam Linux Runtime for native games selected either by you or by Valve Testing as a Compatibility Tool and let SteamTinkerLaunch find it instead. For example, ignore Steam Linux Runtime 3.0 selected by Valve Testing and let SteamTinkerLaunch find and use Steam Linux Runtime 1.0 instead. This can have MAJOR impacts on compatibility, and has NO EFFECT for games using Proton"
 GUI_VORTEXDEVICESCALEFACTOR="Vortex GUI Scale Factor"
 DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vortex GUI scale. Defaults to 1.0, but if you want a larger GUI you can set it to match your display's scale factor (or the largest scale factor, if using multiple across displays)"
+GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
+GUI_STLSHMDIR="Current session logging directory"
+GUI_STLPERGAMELOGSDIR="Per-game log files"

--- a/lang/dutch.txt
+++ b/lang/dutch.txt
@@ -1281,3 +1281,6 @@ GUI_IGNORECOMPATSLR="Ignore Native Linux Steam Linux Runtime from Compatibility 
 DESC_IGNORECOMPATSLR="ignore Steam Linux Runtime for native games selected either by you or by Valve Testing as a Compatibility Tool and let SteamTinkerLaunch find it instead. For example, ignore Steam Linux Runtime 3.0 selected by Valve Testing and let SteamTinkerLaunch find and use Steam Linux Runtime 1.0 instead. This can have MAJOR impacts on compatibility, and has NO EFFECT for games using Proton"
 GUI_VORTEXDEVICESCALEFACTOR="Vortex GUI Scale Factor"
 DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vortex GUI scale. Defaults to 1.0, but if you want a larger GUI you can set it to match your display's scale factor (or the largest scale factor, if using multiple across displays)"
+GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
+GUI_STLSHMDIR="Current session logging directory"
+GUI_STLPERGAMELOGSDIR="Per-game log files"

--- a/lang/english.txt
+++ b/lang/english.txt
@@ -1283,3 +1283,6 @@ GUI_IGNORECOMPATSLR="Ignore Native Linux Steam Linux Runtime from Compatibility 
 DESC_IGNORECOMPATSLR="ignore Steam Linux Runtime for native games selected either by you or by Valve Testing as a Compatibility Tool and let SteamTinkerLaunch find it instead. For example, ignore Steam Linux Runtime 3.0 selected by Valve Testing and let SteamTinkerLaunch find and use Steam Linux Runtime 1.0 instead. This can have MAJOR impacts on compatibility, and has NO EFFECT for games using Proton"
 GUI_VORTEXDEVICESCALEFACTOR="Vortex GUI Scale Factor"
 DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vortex GUI scale. Defaults to 1.0, but if you want a larger GUI you can set it to match your display's scale factor (or the largest scale factor, if using multiple across displays)"
+GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
+GUI_STLSHMDIR="Current session logging directory"
+GUI_STLPERGAMELOGSDIR="Per-game log files"

--- a/lang/englishUK.txt
+++ b/lang/englishUK.txt
@@ -1285,3 +1285,6 @@ GUI_IGNORECOMPATSLR="Ignore Native Linux Steam Linux Runtime from Compatibility 
 DESC_IGNORECOMPATSLR="ignore Steam Linux Runtime for native games selected either by you or by Valve Testing as a Compatibility Tool and let SteamTinkerLaunch find it instead. For example, ignore Steam Linux Runtime 3.0 selected by Valve Testing and let SteamTinkerLaunch find and use Steam Linux Runtime 1.0 instead. This can have MAJOR impacts on compatibility, and has NO EFFECT for games using Proton"
 GUI_VORTEXDEVICESCALEFACTOR="Vortex GUI Scale Factor"
 DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vortex GUI scale. Defaults to 1.0, but if you want a larger GUI you can set it to match your display's scale factor (or the largest scale factor, if using multiple across displays)"
+GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
+GUI_STLSHMDIR="Current session logging directory"
+GUI_STLPERGAMELOGSDIR="Per-game log files"

--- a/lang/french.txt
+++ b/lang/french.txt
@@ -1282,3 +1282,6 @@ GUI_IGNORECOMPATSLR="Ignore Native Linux Steam Linux Runtime from Compatibility 
 DESC_IGNORECOMPATSLR="ignore Steam Linux Runtime for native games selected either by you or by Valve Testing as a Compatibility Tool and let SteamTinkerLaunch find it instead. For example, ignore Steam Linux Runtime 3.0 selected by Valve Testing and let SteamTinkerLaunch find and use Steam Linux Runtime 1.0 instead. This can have MAJOR impacts on compatibility, and has NO EFFECT for games using Proton"
 GUI_VORTEXDEVICESCALEFACTOR="Vortex GUI Scale Factor"
 DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vortex GUI scale. Defaults to 1.0, but if you want a larger GUI you can set it to match your display's scale factor (or the largest scale factor, if using multiple across displays)"
+GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
+GUI_STLSHMDIR="Current session logging directory"
+GUI_STLPERGAMELOGSDIR="Per-game log files"

--- a/lang/german.txt
+++ b/lang/german.txt
@@ -1285,3 +1285,6 @@ GUI_IGNORECOMPATSLR="Ignore Native Linux Steam Linux Runtime from Compatibility 
 DESC_IGNORECOMPATSLR="ignore Steam Linux Runtime for native games selected either by you or by Valve Testing as a Compatibility Tool and let SteamTinkerLaunch find it instead. For example, ignore Steam Linux Runtime 3.0 selected by Valve Testing and let SteamTinkerLaunch find and use Steam Linux Runtime 1.0 instead. This can have MAJOR impacts on compatibility, and has NO EFFECT for games using Proton"
 GUI_VORTEXDEVICESCALEFACTOR="Vortex GUI Scale Factor"
 DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vortex GUI scale. Defaults to 1.0, but if you want a larger GUI you can set it to match your display's scale factor (or the largest scale factor, if using multiple across displays)"
+GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
+GUI_STLSHMDIR="Current session logging directory"
+GUI_STLPERGAMELOGSDIR="Per-game log files"

--- a/lang/italian.txt
+++ b/lang/italian.txt
@@ -1283,3 +1283,6 @@ GUI_IGNORECOMPATSLR="Ignore Native Linux Steam Linux Runtime from Compatibility 
 DESC_IGNORECOMPATSLR="ignore Steam Linux Runtime for native games selected either by you or by Valve Testing as a Compatibility Tool and let SteamTinkerLaunch find it instead. For example, ignore Steam Linux Runtime 3.0 selected by Valve Testing and let SteamTinkerLaunch find and use Steam Linux Runtime 1.0 instead. This can have MAJOR impacts on compatibility, and has NO EFFECT for games using Proton"
 GUI_VORTEXDEVICESCALEFACTOR="Vortex GUI Scale Factor"
 DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vortex GUI scale. Defaults to 1.0, but if you want a larger GUI you can set it to match your display's scale factor (or the largest scale factor, if using multiple across displays)"
+GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
+GUI_STLSHMDIR="Current session logging directory"
+GUI_STLPERGAMELOGSDIR="Per-game log files"

--- a/lang/polish.txt
+++ b/lang/polish.txt
@@ -1283,3 +1283,6 @@ GUI_IGNORECOMPATSLR="Ignore Native Linux Steam Linux Runtime from Compatibility 
 DESC_IGNORECOMPATSLR="ignore Steam Linux Runtime for native games selected either by you or by Valve Testing as a Compatibility Tool and let SteamTinkerLaunch find it instead. For example, ignore Steam Linux Runtime 3.0 selected by Valve Testing and let SteamTinkerLaunch find and use Steam Linux Runtime 1.0 instead. This can have MAJOR impacts on compatibility, and has NO EFFECT for games using Proton"
 GUI_VORTEXDEVICESCALEFACTOR="Vortex GUI Scale Factor"
 DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vortex GUI scale. Defaults to 1.0, but if you want a larger GUI you can set it to match your display's scale factor (or the largest scale factor, if using multiple across displays)"
+GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
+GUI_STLSHMDIR="Current session logging directory"
+GUI_STLPERGAMELOGSDIR="Per-game log files"

--- a/lang/russian.txt
+++ b/lang/russian.txt
@@ -1283,3 +1283,6 @@ GUI_IGNORECOMPATSLR="Ignore Native Linux Steam Linux Runtime from Compatibility 
 DESC_IGNORECOMPATSLR="ignore Steam Linux Runtime for native games selected either by you or by Valve Testing as a Compatibility Tool and let SteamTinkerLaunch find it instead. For example, ignore Steam Linux Runtime 3.0 selected by Valve Testing and let SteamTinkerLaunch find and use Steam Linux Runtime 1.0 instead. This can have MAJOR impacts on compatibility, and has NO EFFECT for games using Proton"
 GUI_VORTEXDEVICESCALEFACTOR="Vortex GUI Scale Factor"
 DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vortex GUI scale. Defaults to 1.0, but if you want a larger GUI you can set it to match your display's scale factor (or the largest scale factor, if using multiple across displays)"
+GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
+GUI_STLSHMDIR="Current session logging directory"
+GUI_STLPERGAMELOGSDIR="Per-game log files"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240616-1"
+PROGVERS="v14.0.20240612-1 (logging-access-improvements)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -15781,9 +15781,12 @@ function wineVortexRun {
 	## Only use SLR is available and (if user explicitly wants to run Vortex with dotnet OR if dotnet6 is not already installed), because the SLR can cause hardlink deployment to fail
 	## See also: https://github.com/sonic2kk/steamtinkerlaunch/issues/828
 
+	writelog "INFO" "${FUNCNAME[0]} - Vortex logs will be stored at '${VWRUN}'"
 	if [[ -n "${SLRCMD[*]}" && ( "$VORTEXUSESLRPOSTINSTALL" -eq 1 || ! -d "$VORTEXPFX/$DRC/Program Files/dotnet" ) ]]; then
+		writelog "INFO" "${FUNCNAME[0]} - PATH=\"${SLTPATH}\" LD_LIBRARY_PATH=\"\" WINE=\"${VORTEXWINE}\" WINEARCH=\"win64\" WINEDEBUG=\"-all\" WINEPREFIX=\"${VORTEXPFX}\" \"${SLRCMD[@]}\" \"$@\""
 		PATH="$STLPATH" LD_LIBRARY_PATH="" LD_PRELOAD="" WINE="$VORTEXWINE" WINEARCH="win64" WINEDEBUG="-all" WINEPREFIX="$VORTEXPFX" "${SLRCMD[@]}" "$@" > "$VWRUN" 2>/dev/null
 	else
+		writelog "INFO" "${FUNCNAME[0]} - PATH=\"${SLTPATH}\" LD_LIBRARY_PATH=\"\" WINE=\"${VORTEXWINE}\" WINEARCH=\"win64\" WINEDEBUG=\"-all\" WINEPREFIX=\"${VORTEXPFX}\" \"$@\""
 		PATH="$STLPATH" LD_LIBRARY_PATH="" LD_PRELOAD="" WINE="$VORTEXWINE" WINEARCH="win64" WINEDEBUG="-all" WINEPREFIX="$VORTEXPFX" "$@" > "$VWRUN" 2>/dev/null
 	fi
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240612-3 (logging-access-improvements)"
+PROGVERS="v14.0.20240612-4 (logging-access-improvements)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -15801,10 +15801,10 @@ function wineVortexRun {
 
 	writelog "INFO" "${FUNCNAME[0]} - Vortex logs will be stored at '${VWRUN}'"
 	if [[ -n "${SLRCMD[*]}" && ( "$VORTEXUSESLRPOSTINSTALL" -eq 1 || ! -d "$VORTEXPFX/$DRC/Program Files/dotnet" ) ]]; then
-		writelog "INFO" "${FUNCNAME[0]} - PATH=\"${SLTPATH}\" LD_LIBRARY_PATH=\"\" WINE=\"${VORTEXWINE}\" WINEARCH=\"win64\" WINEDEBUG=\"-all\" WINEPREFIX=\"${VORTEXPFX}\" \"${SLRCMD[@]}\" \"$@\""
+		writelog "INFO" "${FUNCNAME[0]} - PATH=\"${SLTPATH}\" LD_LIBRARY_PATH=\"\" WINE=\"${VORTEXWINE}\" WINEARCH=\"win64\" WINEDEBUG=\"-all\" WINEPREFIX=\"${VORTEXPFX}\" \"${SLRCMD[*]}\" \"$*\""
 		PATH="$STLPATH" LD_LIBRARY_PATH="" LD_PRELOAD="" WINE="$VORTEXWINE" WINEARCH="win64" WINEDEBUG="-all" WINEPREFIX="$VORTEXPFX" "${SLRCMD[@]}" "$@" > "$VWRUN" 2>/dev/null
 	else
-		writelog "INFO" "${FUNCNAME[0]} - PATH=\"${SLTPATH}\" LD_LIBRARY_PATH=\"\" WINE=\"${VORTEXWINE}\" WINEARCH=\"win64\" WINEDEBUG=\"-all\" WINEPREFIX=\"${VORTEXPFX}\" \"$@\""
+		writelog "INFO" "${FUNCNAME[0]} - PATH=\"${SLTPATH}\" LD_LIBRARY_PATH=\"\" WINE=\"${VORTEXWINE}\" WINEARCH=\"win64\" WINEDEBUG=\"-all\" WINEPREFIX=\"${VORTEXPFX}\" \"$*\""
 		PATH="$STLPATH" LD_LIBRARY_PATH="" LD_PRELOAD="" WINE="$VORTEXWINE" WINEARCH="win64" WINEDEBUG="-all" WINEPREFIX="$VORTEXPFX" "$@" > "$VWRUN" 2>/dev/null
 	fi
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240612-4 (logging-access-improvements)"
+PROGVERS="v14.0.20240616-2"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240612-1 (logging-access-improvements)"
+PROGVERS="v14.0.20240612-3 (logging-access-improvements)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -12958,6 +12958,24 @@ function setGameFilesArray {
 	if [ -f "$MAHUCID/${AID}.conf" ]; then
 		GamDesc+=("$GUI_MANGOHUDGAMECFG")
 		GamFiles+=("$MAHUCID/${AID}.conf")
+	fi
+
+	# Open /dev/shm/steamtinkerlaunch directory
+	if [ -d "$STLSHM" ]; then
+		GamDesc+=("$GUI_STLSHMDIR")
+		GamFiles+=("$STLSHM")
+	fi
+
+	# Open logfile at /dev/shm/steamtinkerlaunch/steamtinkerlaunch.log
+	if [ -f "$TEMPLOG" ]; then
+		GamDesc+=("$GUI_STLSHMLOG")
+		GamFiles+=("$TEMPLOG")
+	fi
+
+	# Open game logging directory at, by default, STLCFGDIR/logs/steamtinkerlaunch
+	if [ -d "$LOGDIR" ]; then
+		GamDesc+=("$GUI_STLPERGAMELOGSDIR")
+		GamFiles+=("$LOGDIR")
 	fi
 
 	createCustomCfgs


### PR DESCRIPTION
Based on discussion in #1118.

This PR does a few things:
- Add logging for the Vortex start command, so it can more easily be copied and ran manually for troubleshooting
- Add some SteamTinkerLaunch log paths to the "Game Files" menu:
    - Path to `/dev/shm/steamtinkerlaunch/steamtinkerlaunch.log` file, so that it can be opened graphically.
    - Path to `/dev/shm/steamtinkerlaunch` folder, which may contain other logs specific to that session.
    - Path to the SteamTinkerLaunch log directory, which is a configurable path, but defaults to `${STLCFGDIR}/logs/steamtinkerlaunch`.

As per usual, if `xdg-open` is not available on the system, these files cannot be opened. If the paths don't exist in the first place when the menu is being opened, they won't be displayed on the menu (following the existing pattern).

TODO:
- [x] Update remaining langfiles