### PR TITLE
Custom Command: Allow Using Steam Linux Runtime with Custom Commands

### DIFF
--- a/lang/chinese.txt
+++ b/lang/chinese.txt
@@ -1287,3 +1287,5 @@ DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vor
 GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
 GUI_STLSHMDIR="Current session logging directory"
 GUI_STLPERGAMELOGSDIR="Per-game log files"
+GUI_CUSTOMCMD_USESLR="Use Steam Linux Runtime with Custom Command"
+DESC_CUSTOMCMD_USESLR="runs Custom Commands in the Steam Linux Runtime container that games use to improve compatibility, particularly for commands running via Proton (but it works for native commands as well). This option might get in the way of inter-process communication (i.e. an app that looks for a game process) and may be unnecessary for Linux shell scripts"

--- a/lang/dutch.txt
+++ b/lang/dutch.txt
@@ -1284,3 +1284,5 @@ DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vor
 GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
 GUI_STLSHMDIR="Current session logging directory"
 GUI_STLPERGAMELOGSDIR="Per-game log files"
+GUI_CUSTOMCMD_USESLR="Use Steam Linux Runtime with Custom Command"
+DESC_CUSTOMCMD_USESLR="runs Custom Commands in the Steam Linux Runtime container that games use to improve compatibility, particularly for commands running via Proton (but it works for native commands as well). This option might get in the way of inter-process communication (i.e. an app that looks for a game process) and may be unnecessary for Linux shell scripts"

--- a/lang/english.txt
+++ b/lang/english.txt
@@ -1286,3 +1286,5 @@ DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vor
 GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
 GUI_STLSHMDIR="Current session logging directory"
 GUI_STLPERGAMELOGSDIR="Per-game log files"
+GUI_CUSTOMCMD_USESLR="Use Steam Linux Runtime with Custom Command"
+DESC_CUSTOMCMD_USESLR="runs Custom Commands in the Steam Linux Runtime container that games use to improve compatibility, particularly for commands running via Proton (but it works for native commands as well). This option might get in the way of inter-process communication (i.e. an app that looks for a game process) and may be unnecessary for Linux shell scripts"

--- a/lang/englishUK.txt
+++ b/lang/englishUK.txt
@@ -1288,3 +1288,5 @@ DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vor
 GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
 GUI_STLSHMDIR="Current session logging directory"
 GUI_STLPERGAMELOGSDIR="Per-game log files"
+GUI_CUSTOMCMD_USESLR="Use Steam Linux Runtime with Custom Command"
+DESC_CUSTOMCMD_USESLR="runs Custom Commands in the Steam Linux Runtime container that games use to improve compatibility, particularly for commands running via Proton (but it works for native commands as well). This option might get in the way of inter-process communication (i.e. an app that looks for a game process) and may be unnecessary for Linux shell scripts"

--- a/lang/french.txt
+++ b/lang/french.txt
@@ -1285,3 +1285,5 @@ DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vor
 GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
 GUI_STLSHMDIR="Current session logging directory"
 GUI_STLPERGAMELOGSDIR="Per-game log files"
+GUI_CUSTOMCMD_USESLR="Use Steam Linux Runtime with Custom Command"
+DESC_CUSTOMCMD_USESLR="runs Custom Commands in the Steam Linux Runtime container that games use to improve compatibility, particularly for commands running via Proton (but it works for native commands as well). This option might get in the way of inter-process communication (i.e. an app that looks for a game process) and may be unnecessary for Linux shell scripts"

--- a/lang/german.txt
+++ b/lang/german.txt
@@ -1288,3 +1288,5 @@ DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vor
 GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
 GUI_STLSHMDIR="Current session logging directory"
 GUI_STLPERGAMELOGSDIR="Per-game log files"
+GUI_CUSTOMCMD_USESLR="Use Steam Linux Runtime with Custom Command"
+DESC_CUSTOMCMD_USESLR="runs Custom Commands in the Steam Linux Runtime container that games use to improve compatibility, particularly for commands running via Proton (but it works for native commands as well). This option might get in the way of inter-process communication (i.e. an app that looks for a game process) and may be unnecessary for Linux shell scripts"

--- a/lang/italian.txt
+++ b/lang/italian.txt
@@ -1286,3 +1286,5 @@ DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vor
 GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
 GUI_STLSHMDIR="Current session logging directory"
 GUI_STLPERGAMELOGSDIR="Per-game log files"
+GUI_CUSTOMCMD_USESLR="Use Steam Linux Runtime with Custom Command"
+DESC_CUSTOMCMD_USESLR="runs Custom Commands in the Steam Linux Runtime container that games use to improve compatibility, particularly for commands running via Proton (but it works for native commands as well). This option might get in the way of inter-process communication (i.e. an app that looks for a game process) and may be unnecessary for Linux shell scripts"

--- a/lang/polish.txt
+++ b/lang/polish.txt
@@ -1286,3 +1286,5 @@ DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vor
 GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
 GUI_STLSHMDIR="Current session logging directory"
 GUI_STLPERGAMELOGSDIR="Per-game log files"
+GUI_CUSTOMCMD_USESLR="Use Steam Linux Runtime with Custom Command"
+DESC_CUSTOMCMD_USESLR="runs Custom Commands in the Steam Linux Runtime container that games use to improve compatibility, particularly for commands running via Proton (but it works for native commands as well). This option might get in the way of inter-process communication (i.e. an app that looks for a game process) and may be unnecessary for Linux shell scripts"

--- a/lang/russian.txt
+++ b/lang/russian.txt
@@ -1286,3 +1286,5 @@ DESC_VORTEXDEVICESCALEFACTOR="uses the --device-scale-factor flag to set the Vor
 GUI_STLSHMLOG="Current SteamTinkerLaunch log file"
 GUI_STLSHMDIR="Current session logging directory"
 GUI_STLPERGAMELOGSDIR="Per-game log files"
+GUI_CUSTOMCMD_USESLR="Use Steam Linux Runtime with Custom Command"
+DESC_CUSTOMCMD_USESLR="runs Custom Commands in the Steam Linux Runtime container that games use to improve compatibility, particularly for commands running via Proton (but it works for native commands as well). This option might get in the way of inter-process communication (i.e. an app that looks for a game process) and may be unnecessary for Linux shell scripts"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -12890,7 +12890,6 @@ function launchCustomProg {
 				setNonGameSLRReap "2"
 			fi
 
-			# TODO if this works, it's much simpler than what we use in extProtonRun -- Can we make the logic as simple as this?
 			if [ -n "${SLRCMD[*]}" ]; then
 				writelog "INFO" "${FUNCNAME[0]} - Gotten Steam Linux Runtime for native launch, using RUNEXTPROGRAMARGS array to contain it and add it to launch command"
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240616-2 (customcmd-slr-ver-2)"
+PROGVERS="v14.0.20240617-1 (customcmd-slr-ver-2)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -12881,6 +12881,36 @@ function launchCustomProg {
 			# TODO set native Linux SLR here and append to RUNEXTPROGRAMARGS
 			# * Do we need to add a "force native" var to setSLRReap? Game could be Proton but customcmd could be native, need to handle both
 			# TODO should respect selected SLR once #1087 is implemented
+			if [ "$__DEBUG_CUSTCMD_SLR" -eq 1 ]; then
+				unset "${SLRCMD[@]}"
+
+				writelog "INFO" "${FUNCNAME[0]} - Steam Linux Runtime enabled, attempting to fetch Steam Linux Runtime for native Custom Command"
+				setNonGameSLRReap  # One-Time Run calls this without any arguments for native titles, maybe it'll work here?
+			fi
+
+			# TODO if this works, it's much simpler than what we use in extProtonRun -- Can we make the logic as simple as this?
+			if [ -n "${SLRCMD[*]}" ]; then
+				writelog "INFO" "${FUNCNAME[0]} - Got Steam Linux Runtime for native title: ${SLRCMD[*]}"
+
+				OLDRUNEXTPROGRAMARGS=( "${RUNEXTPROGRAMARGS[@]}" )
+
+				unset "${RUNEXTPROGRAMARGS[@]}"
+				RUNEXTPROGRAMARGS=( "${SLRCMD[@]}" )
+
+				# OLDRUNEXTPROGRAMARGS should only contain one item, the passed args for the custom command
+				# if the first item here is not empty, assume we have to include the old pass args in the new array
+				#
+				# if blank, it means OLDRUNEXTPROGRAMARGS was most likely empty (or started with a blank element, which would cause a crash anyway)
+				# so we can just create RUNEXTPROGRAMARGS with the SLR as the only element
+				if [ -n "${OLDRUNEXTPROGRAMARGS[0]}" ]; then
+					writelog "INFO" "${FUNCNAME[0]} - Seems like some arguments were given to the custom command, including them alongside the Steam Linux Runtime arguments"
+					RUNEXTPROGRAMARGS+=( "${OLDRUNEXTPROGRAMARGS[@]}" )
+				fi
+
+				unset "${SLRCMD[@]}"
+			elif [ -z "${SLRCMD[*]}" ] && [ "$__DEBUG_CUSTCMD_SLR" -eq 1 ]; then
+				writelog "WARN" "${FUNCNAME[0]} - Attempted to fetch Steam Linux Runtime but failed to find one!"
+			fi
 
 			# Launch native custom command
 			NATIVEPROGNAME="$( basename "$LACO" )"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240616-3"
+PROGVERS="v14.0.20240516-2 (customcmd-slr-ver-2)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -7082,6 +7082,7 @@ function extProtonRun {
 	PROGARGS="$3"
 	EXTPROGRAMARGS="$4"  # e.g. args like GameScope/GameMode taken from `buildCustomCmdLaunch` for ONLY_CUSTOMCMD
 	EXTWINERUN=0
+	EXTPROTUSESLR="${5:-0}"  # Should extProtonRun fetch and use SLR (default to 0 -- turned off)
 
 	if [ "$USEWINE" -eq 1 ] && [[ ! "$WINEVERSION" =~ ${DUMMYBIN}$ ]] && [ "$WINEVERSION" != "$NON" ]; then
 		EXTWINERUN=1
@@ -7143,17 +7144,38 @@ function extProtonRun {
 			mapfile -d " " -t -O "${#RUNEXTPROGRAMARGS[@]}" RUNEXTPROGRAMARGS < <(printf '%s' "$EXTPROGRAMARGS")
 		fi
 
-		# __DEBUG_EXTPROTRUN_SLR=1
-		# if [ "$__DEBUG_EXTPROTRUN_SLR" -eq 1 ]; Then
-		# 	writelog "INFO" "${FUNCNAME[0]} - Running custom command with Proton SLR"
-		# 	setSLRReap
+		# Have to set SLR in extProtonRun because we can't pass the array to the function
+		# Hopefully unsetting is safe and doesn't mean places that need the SLR will lose it from this 'unset'
+		if [ "$EXTPROTUSESLR" -eq 1 ]; then
+			writelog "INFO" "${FUNCNAME[0]} - EXTPROTUSESLR is '$EXTPROTUSESLR' -- Attempting to find and use SLR with extProtonRun"
+			
+			unset "${SLRCMD[@]}"
+			setSLRReap
+		fi
 
-		# 	if [ -n "${SLRCMD[0]}" ]; then
-		# 		writelog "INFO" "${FUNCNAME[0]} - Appending SLR to "
-		# 	else
-		# 		writelog "WARN" "${FUNCNAME[0]} - Could not find SLR! extProtonRun will NOT use "
-		# 	fi
-		# fi
+		# append SLR to beginning of RUNEXTPROGRAMARGS, if SLR is defined
+		# TODO this is ugly, can it be done better?
+		if [ -n "${SLRCMD[*]}" ]; then
+			writelog "INFO" "${FUNCNAME[0]} - Gotten SLR, using RUNEXTPROGRAMARGS array to contain it and add it to launch command"
+			
+			if [ -n "${RUNEXTPROGRAMARGS[*]}" ]; then
+				writelog "INFO" "${FUNCNAME[0]} - Backing up existing RUNEXTPROGRAMARGS ('${RUNEXTPROGRAMARGS[*]}')"
+				OLDRUNEXTPROGRAMARGS=( "${RUNEXTPROGRAMARGS[@]}" )
+			fi
+
+			unset "${RUNEXTPROGRAMARGS[@]}"
+			RUNEXTPROGRAMARGS=( "${SLRCMD[@]}" )
+
+			if [ -n "${OLDRUNEXTPROGRAMARGS[*]}" ]; then
+				writelog "INFO" "${FUNCNAME[0]} - Restoring OLDRUNEXTPROGRAMARGS ('${OLDRUNEXTPROGRAMARGS[*]}')"
+				RUNEXTPROGRAMARGS+=( "${OLDRUNEXTPROGRAMARGS[@]}" )
+			fi
+
+			writelog "INFO" "${FUNCNAME[0]} - RUNEXTPROGRAMARGS is now '${RUNEXTPROGRAMARGS[*]}'"
+		else
+			writelog "WARN" "${FUNCNAME[0]} - EXTPROTUSESLR was '$EXTPROTUSESLR' but SLR was not found -- extProtonRun will NOT be able to use SLR even though it was requested!"
+		fi
+		unset "${SLRCMD[@]}"
 
 		# TODO pass "$EXTPROGRAMARGS" to programs running with Wine as well(?)
 		# TODO refactor a bit to be a little cleaner if possible
@@ -7239,7 +7261,19 @@ function extProtonRun {
 				else
 					notiShow "$( strFix "$NOTY_CUSTPROG_REG" "$CUSTPROGNAME" )"
 					if [ -n "${RUNEXTPROGRAMARGS[0]}" ]; then
-						"${RUNEXTPROGRAMARGS[@]}" "$RUNPROTON" run "$PROGRAM" 2>&1 | tee "$STLSHM/${FUNCNAME[0]}.log"
+						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[0]}'"
+						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[1]}'"
+						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[2]}'"
+						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[3]}'"
+						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[4]}'"
+						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[5]}'"
+						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[6]}'"
+						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[7]}'"
+						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[8]}'"
+						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[9]}'"
+						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[10]}'"
+						# writelog "INFO" "${FUNCNAME[0]} - \"${RUNEXTPROGRAMARGS[*]}\" \"$RUNPROTON\" run \"$PROGRAM\""
+						"${RUNEXTPROGRAMARGS[@]}" "$RUNPROTON" waitforexitandrun "$PROGRAM" 2>&1 | tee "$STLSHM/${FUNCNAME[0]}.log"
 					else
 						"$RUNPROTON" run "$PROGRAM" 2>&1 | tee "$STLSHM/${FUNCNAME[0]}.log"
 					fi
@@ -12819,30 +12853,28 @@ function launchCustomProg {
 				writelog "INFO" "${FUNCNAME[0]} - '$CUSTCOM' seems to be a MS Windows program - starting through proton"
 			fi
 
-			# TODO set Proton SLR here and add to CUSTOMCMD_ARGS if defined
-
 			if [ "$USEWICO" -eq 1 ] && [ "$(file "$CUSTCOM" | grep -c "(console)")" -eq 1 ]; then  # Command line Wine/Proton custom program
 				writelog "INFO" "${FUNCNAME[0]} - '$CUSTCOM' seems to be a MS console program - starting using '$WICO'"
 				if [ "$FORK_CUSTOMCMD" -eq 1 ]; then
 					writelog "INFO" "${FUNCNAME[0]} - FORK_CUSTOMCMD is set to 1 - forking the custom program in background and continue"
-					extProtonRun "FC" "$LACO" "$CUSTOMCMD_ARGS"
+					extProtonRun "FC" "$LACO" "$CUSTOMCMD_ARGS" "" "${__DEBUG_CUSTCMD_SLR}"
 				elif [ "$ONLY_CUSTOMCMD" -eq 1 ] && [ -n "${FINALOUTCMD[*]}" ]; then
-					writelog "INFO" "${FUNCNAME[0]} - ONLY_CUSTOMCMD is set to 1 and we have some arguments in FINALOUTCMD - passing to extProtonRun to build a valid start command"
-					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS" "$FINALOUTCMD"  # extProtonRun will handle adding the FINALOUTCMD args to
+					writelog "INFO" "${FUNCNAME[0]} - ONLY_CUSTOMCMD is set to 1 and we have some arguments in FINALOUTCMD - passing to extProtonRun to build a valid start command"	
+					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS" "$FINALOUTCMD" "${__DEBUG_CUSTCMD_SLR}"  # extProtonRun will handle adding the FINALOUTCMD args to
 				else
-					extProtonRun "RC" "$LACO" "$CUSTOMCMD_ARGS"
+					extProtonRun "RC" "$LACO" "$CUSTOMCMD_ARGS" "" "${__DEBUG_CUSTCMD_SLR}"
 				fi
 			else  # GUI Wine/Proton program
 				writelog "INFO" "${FUNCNAME[0]} - '$CUSTCOM' seems to be a MS gui program - starting regularly"
 
 				if [ "$FORK_CUSTOMCMD" -eq 1 ]; then
 					writelog "INFO" "${FUNCNAME[0]} - FORK_CUSTOMCMD is set to 1 - forking the custom program in background and continue"
-					extProtonRun "F" "$LACO" "$CUSTOMCMD_ARGS"
+					extProtonRun "F" "$LACO" "$CUSTOMCMD_ARGS" "" "${__DEBUG_CUSTCMD_SLR}"
 				elif [ "$ONLY_CUSTOMCMD" -eq 1 ] && [ -n "$FINALOUTCMD" ]; then
 					writelog "INFO" "${FUNCNAME[0]} - ONLY_CUSTOMCMD is set to 1 and we have some arguments in FINALOUTCMD - passing to extProtonRun to build a valid start command"
-					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS" "${FINALOUTCMD[*]}"  # extProtonRun will handle adding the FINALOUTCMD args
+					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS" "${FINALOUTCMD[*]}" "${__DEBUG_CUSTCMD_SLR}""${__DEBUG_CUSTCMD_SLR}"  # extProtonRun will handle adding the FINALOUTCMD args
 				else
-					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS"
+					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS" "" "${__DEBUG_CUSTCMD_SLR}"
 				fi
 			fi
 		else  # Native custom command
@@ -12868,6 +12900,7 @@ function launchCustomProg {
 			FWAIT=2
 
 			# TODO set native Linux SLR here and append to RUNEXTPROGRAMARGS
+			# * Do we need to add a "force native" var to setSLRReap? Game could be Proton but customcmd could be native, need to handle both
 			# TODO should respect selected SLR once #1087 is implemented
 
 			# Launch native custom command

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240516-2 (customcmd-slr-ver-2)"
+PROGVERS="v14.0.20240616-2 (customcmd-slr-ver-2)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -7261,18 +7261,7 @@ function extProtonRun {
 				else
 					notiShow "$( strFix "$NOTY_CUSTPROG_REG" "$CUSTPROGNAME" )"
 					if [ -n "${RUNEXTPROGRAMARGS[0]}" ]; then
-						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[0]}'"
-						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[1]}'"
-						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[2]}'"
-						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[3]}'"
-						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[4]}'"
-						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[5]}'"
-						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[6]}'"
-						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[7]}'"
-						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[8]}'"
-						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[9]}'"
-						writelog "INFO" "${FUNCNAME[0]} - '${RUNEXTPROGRAMARGS[10]}'"
-						# writelog "INFO" "${FUNCNAME[0]} - \"${RUNEXTPROGRAMARGS[*]}\" \"$RUNPROTON\" run \"$PROGRAM\""
+						writelog "INFO" "${FUNCNAME[0]} - \"${RUNEXTPROGRAMARGS[*]}\" \"$RUNPROTON\" run \"$PROGRAM\""
 						"${RUNEXTPROGRAMARGS[@]}" "$RUNPROTON" waitforexitandrun "$PROGRAM" 2>&1 | tee "$STLSHM/${FUNCNAME[0]}.log"
 					else
 						"$RUNPROTON" run "$PROGRAM" 2>&1 | tee "$STLSHM/${FUNCNAME[0]}.log"
@@ -12711,18 +12700,8 @@ function launchCustomProg {
 		CUSTOMCMD="$WICO"
 	fi
 
+	# TODO replace with GUI option
 	__DEBUG_CUSTCMD_SLR=1
-
-	# if [ "$__DEBUG_EXTPROTRUN_SLR" -eq 1 ]; Then
-	# 	writelog "INFO" "${FUNCNAME[0]} - Running custom command with Proton SLR"
-	# 	setSLRReap
-
-	# 	if [ -n "${SLRCMD[0]}" ]; then
-	# 		writelog "INFO" "${FUNCNAME[0]} - Appending SLR to "
-	# 	else
-	# 		writelog "WARN" "${FUNCNAME[0]} - Could not find SLR! extProtonRun will NOT use "
-	# 	fi
-	# fi
 
 	if [ -z "$CUSTOMCMD" ] || [[ "$CUSTOMCMD" =~ ${DUMMYBIN}$ ]]; then
 		writelog "INFO" "${FUNCNAME[0]} - CUSTOMCMD variable is empty - opening file requester"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240617-5 (customcmd-slr-ver-2)"
+PROGVERS="v14.0.20240617-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -3210,6 +3210,7 @@ function setDefaultCfgValues {
 		if [ -z "$ONLY_CUSTOMCMD" ]						; then	ONLY_CUSTOMCMD="0";	fi
 		if [ -z "$FORK_CUSTOMCMD" ]						; then	FORK_CUSTOMCMD="0";	fi
 		if [ -z "$EXTPROGS_CUSTOMCMD" ]					; then  EXTPROGS_CUSTOMCMD="0"; fi
+		if [ -z "$CUSTOMCMD_USESLR" ]					; then  CUSTOMCMD_USESLR="1"; fi
 		if [ -z "$CUSTOMCMDFORCEWIN" ]					; then  CUSTOMCMDFORCEWIN="0"; fi
 		if [ -z "$WAITFORCUSTOMCMD" ]					; then	WAITFORCUSTOMCMD="0"; fi
 		if [ -z "$INJECT_CUSTOMCMD" ]					; then	INJECT_CUSTOMCMD="0"; fi
@@ -3806,6 +3807,8 @@ function saveCfg {
 			echo "FORK_CUSTOMCMD=\"$FORK_CUSTOMCMD\""
 			echo "## $DESC_EXTPROGS_CUSTOMCMD"
 			echo "EXTPROGS_CUSTOMCMD=\"$EXTPROGS_CUSTOMCMD\""
+			echo "## $DESC_CUSTOMCMD_USESLR"
+			echo "CUSTOMCMD_USESLR=\"$CUSTOMCMD_USESLR\""
 			echo "## $DESC_CUSTOMCMD_FORCEWIN"
 			echo "CUSTOMCMDFORCEWIN=\"$CUSTOMCMDFORCEWIN\""
 			echo "## $DESC_WAITFORCUSTOMCMD"
@@ -5678,6 +5681,7 @@ function AllSettingsEntriesDummyFunction {
 --field="     $GUI_CUSTOMCMD_ARGS!$DESC_CUSTOMCMD_ARGS ('CUSTOMCMD_ARGS')" "$( printf "%s" "${CUSTOMCMD_ARGS/#-/ -}" )" `#CAT_Misc` `#MENU_GAME` \
 --field="     $GUI_FORK_CUSTOMCMD!$DESC_FORK_CUSTOMCMD ('FORK_CUSTOMCMD')":CHK "${FORK_CUSTOMCMD/#-/ -}" `#CAT_Misc` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_EXTPROGS_CUSTOMCMD!$DESC_EXTPROGS_CUSTOMCMD ('EXTPROGS_CUSTOMCMD')":CHK "${EXTPROGS_CUSTOMCMD/#-/ -}" `#CAT_Misc` `#SUB_Checkbox` `#MENU_GAME` \
+--field="     $GUI_CUSTOMCMD_USESLR!$DESC_CUSTOMCMD_USESLR ('CUSTOMCMD_USESLR')":CHK "${CUSTOMCMD_USESLR/#-/ -}" `#CAT_Misc` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_ONLY_CUSTOMCMD!$DESC_ONLY_CUSTOMCMD ('ONLY_CUSTOMCMD')":CHK "${ONLY_CUSTOMCMD/#-/ -}" `#CAT_Misc` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_CUSTOMCMD_FORCEWIN!$DESC_CUSTOMCMD_FORCEWIN ('CUSTOMCMDFORCEWIN')":CHK "${CUSTOMCMDFORCEWIN/#-/ -}" `#CAT_Misc` `#SUB_Checkbox` `#MENU_GAME` \
 --field="     $GUI_WAITFORCUSTOMCMD!$DESC_WAITFORCUSTOMCMD ('WAITFORCUSTOMCMD')":NUM "${WAITFORCUSTOMCMD/#-/ -}" `#CAT_Misc` `#SUB_Checkbox` `#MENU_GAME` \
@@ -12703,7 +12707,7 @@ function launchCustomProg {
 	fi
 
 	# TODO replace with GUI option
-	__DEBUG_CUSTCMD_SLR=1
+	# __DEBUG_CUSTCMD_SLR=1
 
 	if [ -z "$CUSTOMCMD" ] || [[ "$CUSTOMCMD" =~ ${DUMMYBIN}$ ]]; then
 		writelog "INFO" "${FUNCNAME[0]} - CUSTOMCMD variable is empty - opening file requester"
@@ -12838,24 +12842,24 @@ function launchCustomProg {
 				writelog "INFO" "${FUNCNAME[0]} - '$CUSTCOM' seems to be a MS console program - starting using '$WICO'"
 				if [ "$FORK_CUSTOMCMD" -eq 1 ]; then
 					writelog "INFO" "${FUNCNAME[0]} - FORK_CUSTOMCMD is set to 1 - forking the custom program in background and continue"
-					extProtonRun "FC" "$LACO" "$CUSTOMCMD_ARGS" "" "${__DEBUG_CUSTCMD_SLR}"
+					extProtonRun "FC" "$LACO" "$CUSTOMCMD_ARGS" "" "${CUSTOMCMD_USESLR}"
 				elif [ "$ONLY_CUSTOMCMD" -eq 1 ] && [ -n "${FINALOUTCMD[*]}" ]; then
 					writelog "INFO" "${FUNCNAME[0]} - ONLY_CUSTOMCMD is set to 1 and we have some arguments in FINALOUTCMD - passing to extProtonRun to build a valid start command"	
-					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS" "$FINALOUTCMD" "${__DEBUG_CUSTCMD_SLR}"  # extProtonRun will handle adding the FINALOUTCMD args to
+					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS" "$FINALOUTCMD" "${CUSTOMCMD_USESLR}"  # extProtonRun will handle adding the FINALOUTCMD args to
 				else
-					extProtonRun "RC" "$LACO" "$CUSTOMCMD_ARGS" "" "${__DEBUG_CUSTCMD_SLR}"
+					extProtonRun "RC" "$LACO" "$CUSTOMCMD_ARGS" "" "${CUSTOMCMD_USESLR}"
 				fi
 			else  # GUI Wine/Proton program
 				writelog "INFO" "${FUNCNAME[0]} - '$CUSTCOM' seems to be a MS gui program - starting regularly"
 
 				if [ "$FORK_CUSTOMCMD" -eq 1 ]; then
 					writelog "INFO" "${FUNCNAME[0]} - FORK_CUSTOMCMD is set to 1 - forking the custom program in background and continue"
-					extProtonRun "F" "$LACO" "$CUSTOMCMD_ARGS" "" "${__DEBUG_CUSTCMD_SLR}"
+					extProtonRun "F" "$LACO" "$CUSTOMCMD_ARGS" "" "${CUSTOMCMD_USESLR}"
 				elif [ "$ONLY_CUSTOMCMD" -eq 1 ] && [ -n "$FINALOUTCMD" ]; then
 					writelog "INFO" "${FUNCNAME[0]} - ONLY_CUSTOMCMD is set to 1 and we have some arguments in FINALOUTCMD - passing to extProtonRun to build a valid start command"
-					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS" "${FINALOUTCMD[*]}" "${__DEBUG_CUSTCMD_SLR}""${__DEBUG_CUSTCMD_SLR}"  # extProtonRun will handle adding the FINALOUTCMD args
+					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS" "${FINALOUTCMD[*]}" "${CUSTOMCMD_USESLR}" "${CUSTOMCMD_USESLR}"  # extProtonRun will handle adding the FINALOUTCMD args
 				else
-					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS" "" "${__DEBUG_CUSTCMD_SLR}"
+					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS" "" "${CUSTOMCMD_USESLR}"
 				fi
 			fi
 		else  # Native custom command
@@ -12883,7 +12887,7 @@ function launchCustomProg {
 			# TODO set native Linux SLR here and append to RUNEXTPROGRAMARGS
 			# * Do we need to add a "force native" var to setSLRReap? Game could be Proton but customcmd could be native, need to handle both
 			# TODO should respect selected SLR once #1087 is implemented
-			if [ "$__DEBUG_CUSTCMD_SLR" -eq 1 ]; then
+			if [ "$CUSTOMCMD_USESLR" -eq 1 ]; then
 				unset "${SLRCMD[@]}"
 
 				writelog "INFO" "${FUNCNAME[0]} - Steam Linux Runtime enabled, attempting to fetch Steam Linux Runtime for native Custom Command"
@@ -12910,7 +12914,7 @@ function launchCustomProg {
 				fi
 
 				unset "${SLRCMD[@]}"
-			elif [ -z "${SLRCMD[*]}" ] && [ "$__DEBUG_CUSTCMD_SLR" -eq 1 ]; then
+			elif [ -z "${SLRCMD[*]}" ] && [ "$CUSTOMCMD_USESLR" -eq 1 ]; then
 				writelog "WARN" "${FUNCNAME[0]} - Attempted to fetch Steam Linux Runtime but failed to find one!"
 			fi
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240617-3 (customcmd-slr-ver-2)"
+PROGVERS="v14.0.20240617-4 (customcmd-slr-ver-2)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -7158,26 +7158,25 @@ function extProtonRun {
 		fi
 
 		# append SLR to beginning of RUNEXTPROGRAMARGS, if SLR is defined
-		# TODO this is ugly, can it be done better?
 		if [ -n "${SLRCMD[*]}" ]; then
-			writelog "INFO" "${FUNCNAME[0]} - Gotten SLR, using RUNEXTPROGRAMARGS array to contain it and add it to launch command"
-			
-			if [ -n "${RUNEXTPROGRAMARGS[*]}" ]; then
-				writelog "INFO" "${FUNCNAME[0]} - Backing up existing RUNEXTPROGRAMARGS ('${RUNEXTPROGRAMARGS[*]}')"
-				OLDRUNEXTPROGRAMARGS=( "${RUNEXTPROGRAMARGS[@]}" )
-			fi
+			writelog "INFO" "${FUNCNAME[0]} - Gotten Steam Linux Runtime for Proton launch, using RUNEXTPROGRAMARGS array to contain it and add it to launch command"
+
+			OLDRUNEXTPROGRAMARGS=( "${RUNEXTPROGRAMARGS[@]}" )
 
 			unset "${RUNEXTPROGRAMARGS[@]}"
 			RUNEXTPROGRAMARGS=( "${SLRCMD[@]}" )
 
-			if [ -n "${OLDRUNEXTPROGRAMARGS[*]}" ]; then
-				writelog "INFO" "${FUNCNAME[0]} - Restoring OLDRUNEXTPROGRAMARGS ('${OLDRUNEXTPROGRAMARGS[*]}')"
+			# OLDRUNEXTPROGRAMARGS should only contain one item, the passed args for the custom command
+			# if the first item here is not empty, assume we have to include the old pass args in the new array
+			#
+			# if blank, it means OLDRUNEXTPROGRAMARGS was most likely empty (or started with a blank element, which would cause a crash anyway)
+			# so we can just create RUNEXTPROGRAMARGS with the SLR as the only element
+			if [ -n "${OLDRUNEXTPROGRAMARGS[0]}" ]; then
+				writelog "INFO" "${FUNCNAME[0]} - Seems like some arguments were given to the custom command, including them alongside the Steam Linux Runtime arguments"
 				RUNEXTPROGRAMARGS+=( "${OLDRUNEXTPROGRAMARGS[@]}" )
 			fi
-
-			writelog "INFO" "${FUNCNAME[0]} - RUNEXTPROGRAMARGS is now '${RUNEXTPROGRAMARGS[*]}'"
-		else
-			writelog "WARN" "${FUNCNAME[0]} - EXTPROTUSESLR was '$EXTPROTUSESLR' but SLR was not found -- extProtonRun will NOT be able to use SLR even though it was requested!"
+		elif [ -z "${SLRCMD[*]}" ] && [ "$CUSTOMCMD_USESLR" -eq 1 ]; then
+			writelog "WARN" "${FUNCNAME[0]} - Attempted to fetch Steam Linux Runtime but failed to find one!"
 		fi
 		unset "${SLRCMD[@]}"
 
@@ -12706,9 +12705,6 @@ function launchCustomProg {
 		CUSTOMCMD="$WICO"
 	fi
 
-	# TODO replace with GUI option
-	# __DEBUG_CUSTCMD_SLR=1
-
 	if [ -z "$CUSTOMCMD" ] || [[ "$CUSTOMCMD" =~ ${DUMMYBIN}$ ]]; then
 		writelog "INFO" "${FUNCNAME[0]} - CUSTOMCMD variable is empty - opening file requester"
 		fixShowGnAid
@@ -12884,8 +12880,6 @@ function launchCustomProg {
 
 			FWAIT=2
 
-			# TODO set native Linux SLR here and append to RUNEXTPROGRAMARGS
-			# * Do we need to add a "force native" var to setSLRReap? Game could be Proton but customcmd could be native, need to handle both
 			# TODO should respect selected SLR once #1087 is implemented
 			if [ "$CUSTOMCMD_USESLR" -eq 1 ]; then
 				unset "${SLRCMD[@]}"
@@ -12896,7 +12890,7 @@ function launchCustomProg {
 
 			# TODO if this works, it's much simpler than what we use in extProtonRun -- Can we make the logic as simple as this?
 			if [ -n "${SLRCMD[*]}" ]; then
-				writelog "INFO" "${FUNCNAME[0]} - Got Steam Linux Runtime for native title: ${SLRCMD[*]}"
+				writelog "INFO" "${FUNCNAME[0]} - Gotten Steam Linux Runtime for native launch, using RUNEXTPROGRAMARGS array to contain it and add it to launch command"
 
 				OLDRUNEXTPROGRAMARGS=( "${RUNEXTPROGRAMARGS[@]}" )
 
@@ -12912,11 +12906,12 @@ function launchCustomProg {
 					writelog "INFO" "${FUNCNAME[0]} - Seems like some arguments were given to the custom command, including them alongside the Steam Linux Runtime arguments"
 					RUNEXTPROGRAMARGS+=( "${OLDRUNEXTPROGRAMARGS[@]}" )
 				fi
-
-				unset "${SLRCMD[@]}"
 			elif [ -z "${SLRCMD[*]}" ] && [ "$CUSTOMCMD_USESLR" -eq 1 ]; then
 				writelog "WARN" "${FUNCNAME[0]} - Attempted to fetch Steam Linux Runtime but failed to find one!"
 			fi
+			unset "${SLRCMD[@]}"
+
+			writelog "INFO" "${FUNCNAME[0]} - RUNEXTPROGRAMARGS is now '${RUNEXTPROGRAMARGS[@]}'"
 
 			# Launch native custom command
 			NATIVEPROGNAME="$( basename "$LACO" )"
@@ -12931,16 +12926,20 @@ function launchCustomProg {
 				if [ "$FORK_CUSTOMCMD" -eq 1 ]; then  # Forked native custom program
 					writelog "INFO" "${FUNCNAME[0]} - FORK_CUSTOMCMD is set to 1 - forking the custom program in background and continue"
 					if [ -n "${RUNEXTPROGRAMARGS[0]}" ]; then
+						writelog "INFO" "${FUNCNAME[0]} - \"${RUNEXTPROGRAMARGS[*]}\" \"${LACO}\" \"${RUNCUSTOMCMD_ARGS[*]}\""
 						(sleep "$FWAIT"; notiShow "$( strFix "$NOTY_CUSTPROG_FORKED_NATIVE" "$NATIVEPROGNAME" )"; "${RUNEXTPROGRAMARGS[@]}" "$LACO" "${RUNCUSTOMCMD_ARGS[@]}") &
 					else
+						writelog "INFO" "${FUNCNAME[0]} - \"${LACO}\" \"${RUNCUSTOMCMD_ARGS[*]}\""
 						(sleep "$FWAIT"; notiShow "$( strFix "$NOTY_CUSTPROG_FORKED_NATIVE" "$NATIVEPROGNAME" )"; "$LACO" "${RUNCUSTOMCMD_ARGS[@]}") &
 					fi
 				else  # Regular native executable
 					writelog "INFO" "${FUNCNAME[0]} - Starting native custom command regularly"
 					notiShow "$( strFix "$NOTY_CUSTPROG_REG_NATIVE" "$NATIVEPROGNAME" )"
 					if [ -n "${RUNEXTPROGRAMARGS[0]}" ]; then
+						writelog "INFO" "${FUNCNAME[0]} - \"${RUNEXTPROGRAMARGS[*]}\" \"${LACO}\" \"${RUNCUSTOMCMD_ARGS[*]}\""
 						"${RUNEXTPROGRAMARGS[@]}" "$LACO" "${RUNCUSTOMCMD_ARGS[@]}"
 					else
+						writelog "INFO" "${FUNCNAME[0]} - \"${LACO}\" \"${RUNCUSTOMCMD_ARGS[*]}\""
 						"$LACO" "${RUNCUSTOMCMD_ARGS[@]}"
 					fi
 				fi

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7158,6 +7158,7 @@ function extProtonRun {
 		fi
 
 		# append SLR to beginning of RUNEXTPROGRAMARGS, if SLR is defined
+		# TODO this is the exact same logic as in launchCustomProg (except the log messages are slightly different), is there any way to share it?
 		if [ -n "${SLRCMD[*]}" ]; then
 			writelog "INFO" "${FUNCNAME[0]} - Gotten Steam Linux Runtime for Proton launch, using RUNEXTPROGRAMARGS array to contain it and add it to launch command"
 
@@ -12890,6 +12891,7 @@ function launchCustomProg {
 				setNonGameSLRReap "2"
 			fi
 
+			# TODO this is the exact same logic as in extProtonRun (except the log messages are slightly different), is there any way to share it?
 			if [ -n "${SLRCMD[*]}" ]; then
 				writelog "INFO" "${FUNCNAME[0]} - Gotten Steam Linux Runtime for native launch, using RUNEXTPROGRAMARGS array to contain it and add it to launch command"
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -12220,6 +12220,7 @@ function OneTimeRunReset {
 }
 
 # Called when a user passes arguments for onetimerun
+# TODO a way to use default game Proton version, either if '--proton' is not supplied or if '--proton="default"'?
 function commandlineOneTimeRun {
 	setOneTimeRunVars "$1"
 	# Get incoming arguments
@@ -12273,6 +12274,7 @@ function commandlineOneTimeRun {
 	fi
 
 	# Ensure EXE is given and that directory to run the exe in is valid, and also ensure we have a valid Proton version to run the exe with
+	# TODO refactor to flatten
 	if [ -n "$OTEXE" ] && [ -f "$OTEXE" ]; then  # Valid executable required (Windows executable or Linux executable/file/etc, not really an EXE for Linux but oh well - Naming is hard!)
 		if [ "$USEEXEDIR" -eq 1 ]; then  # Use EXE dir as working dir
 			OTRUNDIR="$( dirname "$OTEXE" )"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -12911,8 +12911,6 @@ function launchCustomProg {
 			fi
 			unset "${SLRCMD[@]}"
 
-			writelog "INFO" "${FUNCNAME[0]} - RUNEXTPROGRAMARGS is now '${RUNEXTPROGRAMARGS[@]}'"
-
 			# Launch native custom command
 			NATIVEPROGNAME="$( basename "$LACO" )"
 			if [ -n "$1" ]; then

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240617-1 (customcmd-slr-ver-2)"
+PROGVERS="v14.0.20240617-3 (customcmd-slr-ver-2)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240617-4 (customcmd-slr-ver-2)"
+PROGVERS="v14.0.20240617-5 (customcmd-slr-ver-2)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -12885,7 +12885,9 @@ function launchCustomProg {
 				unset "${SLRCMD[@]}"
 
 				writelog "INFO" "${FUNCNAME[0]} - Steam Linux Runtime enabled, attempting to fetch Steam Linux Runtime for native Custom Command"
-				setNonGameSLRReap  # One-Time Run calls this without any arguments for native titles, maybe it'll work here?
+				# "2" is the FORCESLRTYPE, meaning we want to force to get the native SLR -- We do this in case we are trying to launch a native custom command with a Proton title
+				# In this case, setSLRReap is going to have the Proton SLR vars set from the game launch, so we need to force it here to use the native SLR 
+				setNonGameSLRReap "2"
 			fi
 
 			# TODO if this works, it's much simpler than what we use in extProtonRun -- Can we make the logic as simple as this?
@@ -16935,15 +16937,18 @@ function setNonGameSLRReap {
 	HAVEREAP="${HAVEREAP:-0}"
 	HAVESLRCT="${HAVESLRCT:-0}"
 
-	FORCEPROTONSLR="$1"
+	# 0 - No SLR force, let setSLRReap determine what Proton version to use (Default)
+	# 1 - Proton SLR
+	# 2 - Native SLR
+	FORCESLRTYPE="$1"
 
 	# Only get SLRPROTONNAME if we're forcing Proton, otherwise ignore
-	if [ -n "$FORCEPROTONSLR" ] && [ "$FORCEPROTONSLR" -eq 1 ]; then
+	if [ -n "$FORCESLRTYPE" ] && [ "$FORCESLRTYPE" -eq 1 ]; then
 		SLRPROTONNAME="$( getProtPathFromCSV "$2" )"  # This could be the name of the Proton version to run i.e. Vortex
 	fi
 
 	unset "${SLRCMD[@]}"
-	setSLRReap "1" "$FORCEPROTONSLR" "$SLRPROTONNAME"  # Get SLRCMD, optionally enforcing Proton (so we don't fall back to native Linux) and setting the Proton version to fetch the SLR info from (e.g. whether to use soldier, sniper, etc)
+	setSLRReap "1" "$FORCESLRTYPE" "$SLRPROTONNAME"  # Get SLRCMD, optionally enforcing Proton (so we don't fall back to native Linux) and setting the Proton version to fetch the SLR info from (e.g. whether to use soldier, sniper, etc)
 }
 
 function setVortexVars {
@@ -21277,7 +21282,7 @@ function setSLRReap {
 
 	# These variables are only passed for Non-Game SLR launches i.e. Vortex, they are ignored for game launches and use fallback values
 	OVERRIDESLR="$1"  # Always get SLR, ignoring other vars that specify otherwise
-	SLRFORCEPROTON="${2:-0}"  # Force fetch the Proton SLR ignoring value of ISGAME
+	SLRFORCETYPE="${2:-0}"  # Force fetch the Proton SLR (1), or native SLR (2), ignoring value of ISGAME
 	SLRPROTONVER="$3"  # Proton version to fetch the SLR version from (where to find the toolmanifest.vdf from) -- Optional, will fall back to RUNPROTON set by game
 
 	# Allow overriding USESLR/HAVESLR and forcing to fetch the SLR anyway (used for times when SLR is needed outside of regular game launch e.g. Vortex)
@@ -21359,7 +21364,8 @@ function setSLRReap {
 				# Pressure Vessel Funtime 2nd Edition Ver. 2.31
 				writelog "INFO" "${FUNCNAME[0]} - Now executing Pressure Vessel Funtime 2nd Edition Ver. 2.31"
 				# Get SLR Paths
-				if [ "$ISGAME" -eq 3 ] && [ "$SLRFORCEPROTON" -eq 0 ]; then  # ISGAME -eq 3 is always true for running outside of Steam eg One-Time Run...
+				# Use native SLR: if ( ( game is native AND NOT forcing Proton ) OR forcing native )
+				if [[ ( "$ISGAME" -eq 3 && "$SLRFORCETYPE" -eq 0 ) || "$SLRFORCETYPE" -eq 2 ]]; then
 					# Native games already have a hardcoded initial native SLR AppID, so we can get the path from this hardcoded AppID
 					# However they need to get the required "nested" SLR from the toolmanifest from the hardcoded native SLR - This is the SLR that the regular native SLR runs inside of
 					# This nested AppID is stored in the hardcoded SLR's toolmanifest

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7143,6 +7143,18 @@ function extProtonRun {
 			mapfile -d " " -t -O "${#RUNEXTPROGRAMARGS[@]}" RUNEXTPROGRAMARGS < <(printf '%s' "$EXTPROGRAMARGS")
 		fi
 
+		# __DEBUG_EXTPROTRUN_SLR=1
+		# if [ "$__DEBUG_EXTPROTRUN_SLR" -eq 1 ]; Then
+		# 	writelog "INFO" "${FUNCNAME[0]} - Running custom command with Proton SLR"
+		# 	setSLRReap
+
+		# 	if [ -n "${SLRCMD[0]}" ]; then
+		# 		writelog "INFO" "${FUNCNAME[0]} - Appending SLR to "
+		# 	else
+		# 		writelog "WARN" "${FUNCNAME[0]} - Could not find SLR! extProtonRun will NOT use "
+		# 	fi
+		# fi
+
 		# TODO pass "$EXTPROGRAMARGS" to programs running with Wine as well(?)
 		# TODO refactor a bit to be a little cleaner if possible
 		CUSTPROGNAME="$( basename "$PROGRAM" )"
@@ -12665,6 +12677,19 @@ function launchCustomProg {
 		CUSTOMCMD="$WICO"
 	fi
 
+	__DEBUG_CUSTCMD_SLR=1
+
+	# if [ "$__DEBUG_EXTPROTRUN_SLR" -eq 1 ]; Then
+	# 	writelog "INFO" "${FUNCNAME[0]} - Running custom command with Proton SLR"
+	# 	setSLRReap
+
+	# 	if [ -n "${SLRCMD[0]}" ]; then
+	# 		writelog "INFO" "${FUNCNAME[0]} - Appending SLR to "
+	# 	else
+	# 		writelog "WARN" "${FUNCNAME[0]} - Could not find SLR! extProtonRun will NOT use "
+	# 	fi
+	# fi
+
 	if [ -z "$CUSTOMCMD" ] || [[ "$CUSTOMCMD" =~ ${DUMMYBIN}$ ]]; then
 		writelog "INFO" "${FUNCNAME[0]} - CUSTOMCMD variable is empty - opening file requester"
 		fixShowGnAid
@@ -12794,6 +12819,8 @@ function launchCustomProg {
 				writelog "INFO" "${FUNCNAME[0]} - '$CUSTCOM' seems to be a MS Windows program - starting through proton"
 			fi
 
+			# TODO set Proton SLR here and add to CUSTOMCMD_ARGS if defined
+
 			if [ "$USEWICO" -eq 1 ] && [ "$(file "$CUSTCOM" | grep -c "(console)")" -eq 1 ]; then  # Command line Wine/Proton custom program
 				writelog "INFO" "${FUNCNAME[0]} - '$CUSTCOM' seems to be a MS console program - starting using '$WICO'"
 				if [ "$FORK_CUSTOMCMD" -eq 1 ]; then
@@ -12839,6 +12866,9 @@ function launchCustomProg {
 			fi
 
 			FWAIT=2
+
+			# TODO set native Linux SLR here and append to RUNEXTPROGRAMARGS
+			# TODO should respect selected SLR once #1087 is implemented
 
 			# Launch native custom command
 			NATIVEPROGNAME="$( basename "$LACO" )"
@@ -21694,6 +21724,8 @@ function launchSteamGame {
 
 	writelog "INFO" "${FUNCNAME[0]} - Initial game command is '${INGCMD[*]}'"
 
+	# Refetch SLR, in case we set it for custom command as well
+	# i.e. custom command could use native SLR, but we might want to use Proton SLR for the game, or vice versa
 	unset "${SLRCMD[@]}"
 	setSLRReap
 


### PR DESCRIPTION
Adds the ability to use the Steam Linux Runtime with Custom Commands. This should help with compatibility, as Proton is not intended to be used to run games without the Steam Linux Runtime.

This functionality should improve compatibility with custom commands, especially Proton custom commands. This should also mean that, effectively, using a custom command, with `ONLY_CUSTOMCMD` enabled, _and_ with the Steam Linux Runtime option from this PR enabled, allows the custom command to act as a full replacement for the default Steam executable. There are some caveats and limitations (no integration with Steamworks as usual, mod managers won't respect this, etc) but in my testing it acts as a smooth drop-in replacement strategy now even in edge-cases where this didn't work before.

This currently works, but there is no option for this on the UI, it is hardcoded with `__DEBUG_CUSTCMD_SLR` in the code.

<hr>

Note: The implementation here may serve as a basis for using the SLR with Winetricks, see #860.

<hr>

TODO:
- [x] Add checkbox for toggling Steam Linux Runtime
    - [x] Needs tested!!!!
- [x] Add support for Native Linux SLR (currently only Scout 1.0, as 3.0 has slightly different logic needed to fetch, would need handled sepatately as this PR only handles integrating the current SLR logic)
- [ ] Update langfiles
- [ ] Version bump

<hr>

EDIT: The checkbox has been added, and the option for this (`CUSTOMCMD_USESLR`) will be **enabled** by default. This is because it is supposed to improve compatibility. Proton also requires the SLR; many things work without it on some systems but it's still meant to be used. With Native Linux commands, it is unnecessary, but can still be very useful except for things like scripts.

So for broad compatibility, this is enabled by default, but can be disabled in cases where it causes issues. For example it may get in the way of inter-process communication, and it would prevent scripts from accessing things on PATH (as it would be isolated to the container).

The tooltip notes the compatibility benefit and briefly illustrates some limitations.