### PR TITLE
misc: Fix commands being interpreted as game launch if command included `steamapps/common`

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240621-1 (fix-gamelaunch-steamappscommon)"
+PROGVERS="v14.0.20240621-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240617-3 (fix-gamelaunch-steamappscommon)"
+PROGVERS="v14.0.20240618-1 (fix-gamelaunch-steamappscommon)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -26864,10 +26864,14 @@ function main {
 			if grep -q "update" <<< "$@" || grep -q "^play" <<< "$@" ; then
 				commandline "$@"
 			# HACK: Since we check for steamapps/common ($SAC), commands which contain this (such as a one-time run path) will incorrectly get triggered as a game launch
-			#       As a workaround, skip a hardcoded set of commands and pass directly to commandline (i.e. if we have OTR as our first option, pass down to commandline function and run otr)
-			elif grep -qwE "${STLINCOMINGSKIPCOMMANDS}" <<< "${1}"; then
+			#       As a workaround, skip interpreting a hardcoded set of commands as start parameters and pass directly to commandline (i.e. if we have OTR as our first option, pass down to commandline function and run otr)
+			#
+			#       We also check to make sure the first argument doesn't contain any slashes (i.e. game start commands' first argument could be a path, so it would contain a slash)
+			#       This allows us to distinguish between '/home/otr' which could be a game launch command, and the 'otr' command
+			elif grep -qwE "${STLINCOMINGSKIPCOMMANDS}" <<< "${1}" && [[ "${1}" != *"/"* ]]; then
 				commandline "$@"
 			else
+				# If we get here, this should be an actual game start command!
 				setGameVars "$@"
 				if [ "$ISGAME" -eq 2 ] || [ "$ISGAME" -eq 3 ]; then
 					prepareLaunch

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240618-1 (fix-gamelaunch-steamappscommon)"
+PROGVERS="v14.0.20240621-1 (fix-gamelaunch-steamappscommon)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -26859,15 +26859,18 @@ function main {
 		elif grep -q "$SAC" <<< "$@" || grep -q "$L2EA" <<< "$@"; then
 			# We check if incoming commands contain 'steamapps/common' to interpret them as game launch commands
 			# But if $1 is a known command in this list, explicitly pass it to 'commandline' as we know it is NOT a game command
+			# This prevents commands which contain 'steamapps/common' ANYWHERE in their command (including as paths as parameters to other flags) from being interpreted as a game launch
+			#
+			# If $1 is a known steamtinkerlaunch command (with 'steamtinkerlaunch otr', $1 would be 'otr') then intervene and force this to the 'commandline' function as it is a known steamtinkerlaunch command
 			STLINCOMINGSKIPCOMMANDS="otr|onetimerun"
 
 			if grep -q "update" <<< "$@" || grep -q "^play" <<< "$@" ; then
 				commandline "$@"
 			# HACK: Since we check for steamapps/common ($SAC), commands which contain this (such as a one-time run path) will incorrectly get triggered as a game launch
-			#       As a workaround, skip interpreting a hardcoded set of commands as start parameters and pass directly to commandline (i.e. if we have OTR as our first option, pass down to commandline function and run otr)
+			#       As a workaround, skip interpreting a hardcoded set of commands as start parameters and pass directly to commandline (i.e. if we have 'otr' as our first option, pass down to commandline function and run otr)
 			#
 			#       We also check to make sure the first argument doesn't contain any slashes (i.e. game start commands' first argument could be a path, so it would contain a slash)
-			#       This allows us to distinguish between '/home/otr' which could be a game launch command, and the 'otr' command
+			#       This allows us to distinguish between '/home/otr' which could be a game launch command, and the 'steamtinkerlaunch otr' command (where $1 is 'otr')
 			elif grep -qwE "${STLINCOMINGSKIPCOMMANDS}" <<< "${1}" && [[ "${1}" != *"/"* ]]; then
 				commandline "$@"
 			else

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240617-2 (fix-gamelaunch-steamappscommon)"
+PROGVERS="v14.0.20240617-3 (fix-gamelaunch-steamappscommon)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -26857,11 +26857,15 @@ function main {
 				fi
 			fi
 		elif grep -q "$SAC" <<< "$@" || grep -q "$L2EA" <<< "$@"; then
+			# We check if incoming commands contain 'steamapps/common' to interpret them as game launch commands
+			# But if $1 is a known command in this list, explicitly pass it to 'commandline' as we know it is NOT a game command
+			STLINCOMINGSKIPCOMMANDS="otr|onetimerun"
+
 			if grep -q "update" <<< "$@" || grep -q "^play" <<< "$@" ; then
 				commandline "$@"
 			# HACK: Since we check for steamapps/common ($SAC), commands which contain this (such as a one-time run path) will incorrectly get triggered as a game launch
 			#       As a workaround, skip a hardcoded set of commands and pass directly to commandline (i.e. if we have OTR as our first option, pass down to commandline function and run otr)
-			elif grep -qwE "otr|onetimerun" <<< "${1}"; then
+			elif grep -qwE "${STLINCOMINGSKIPCOMMANDS}" <<< "${1}"; then
 				commandline "$@"
 			else
 				setGameVars "$@"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240619-1"
+PROGVERS="v14.0.20240617-1 (fix-gamelaunch-steamappscommon)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -26840,6 +26840,7 @@ function main {
 		writelog "INFO" "${FUNCNAME[0]} - No arguments provided. See '$PROGCMD --help' for possible command line parameters" "E"
 	else
 		writelog "INFO" "${FUNCNAME[0]} - Checking command line: incoming arguments '${*}'"
+		writelog "INFO" "${FUNCNAME[0]} - Checking command line: first argument '${1}'"
 
 		if [ -n "$SteamAppId" ] && [ "$SteamAppId" -eq "0" ]; then
 			if grep -q "\"$1\"" <<< "$(sed -n "/^#STARTCMDLINE/,/^#ENDCMDLINE/p;/^#ENDCMDLINE/q" "$0" | grep if)"; then
@@ -26857,6 +26858,10 @@ function main {
 			fi
 		elif grep -q "$SAC" <<< "$@" || grep -q "$L2EA" <<< "$@"; then
 			if grep -q "update" <<< "$@" || grep -q "^play" <<< "$@" ; then
+				commandline "$@"
+			# HACK: Since we check for steamapps/common ($SAC), commands which contain this (such as a one-time run path) will incorrectly get triggered as a game launch
+			#       As a workaround, skip a hardcoded set of commands and pass directly to commandline (i.e. if we have OTR as our first option, pass down to commandline function and run otr)
+			elif grep -qE "otr|onetimerun" <<< "${1}"; then
 				commandline "$@"
 			else
 				setGameVars "$@"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240617-1 (fix-gamelaunch-steamappscommon)"
+PROGVERS="v14.0.20240617-2 (fix-gamelaunch-steamappscommon)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -26861,7 +26861,7 @@ function main {
 				commandline "$@"
 			# HACK: Since we check for steamapps/common ($SAC), commands which contain this (such as a one-time run path) will incorrectly get triggered as a game launch
 			#       As a workaround, skip a hardcoded set of commands and pass directly to commandline (i.e. if we have OTR as our first option, pass down to commandline function and run otr)
-			elif grep -qE "otr|onetimerun" <<< "${1}"; then
+			elif grep -qwE "otr|onetimerun" <<< "${1}"; then
 				commandline "$@"
 			else
 				setGameVars "$@"


### PR DESCRIPTION
If commands to SteamTinkerLaunch include `steamapps/common`, we incorrectly interpret this as an attempted game launch. This is because SteamTinkerLaunch assumes if a path contains the path to a Steam game that it should be a game launch. An incoming start command might look like this from Proton: `waitforexitandrun "/home/gaben/.local/share/Steam/steamapps/common/Half-Life 3/hl3.exe`. So to detect game launches, SteamTinkerLaunch looks for `steamapps/common` using `grep -q "$SAC"` (where `SA="steamapps"; SAC="$SA/common"`).

For native Linux games, because they can be launched with and without a Steam Linux Runtime - not to mention Proton games can use whacky incoming things for things like `link2ea`, Ubisoft, etc - there is no way I can think of currently to know when the incoming command  to SteamTinkerLaunch is a game launch, and when it is a command, other than to hardcode cases where an incoming command may reasonably contain `steamapps/common`.

One-Time Run suffers quite badly from this bug, where the `--exe` path may contain a steamapps path. The following command would fail: `steamtinkerlaunch otr --exe="/home/gaben/.local/share/Steam/steamapps/common/Half-Life 3/hl3.exe" --proton="GE-Proton9-7"` -- It fails because the path contains `steamapps/common`.

<hr>

Commands which can include `"steamapps/common"` will fail because SteamTinkerLaunch interprets them as game launches even if they are not, because this is the most straightforward way to detect game launches.

This PR fixes the issue by introducing a check on the first incoming argument (the actual command, for example with `steamtinkerlaunch otr`, `$1` is `otr`) to see if it contains a hardcoded list of `grep` values. For now, we only check for `otr`. The reason we only check on `$1` is because we only care to check if the first command is a known SteamTinkerLaunch command; we wouldn't want to exclude commands containing `otr` *anywhere* from being ran as game processes, we only want to skip launching as a game process if the incoming command's first parameter *is a known command that is NOT a game process, i.e. a command defined by SteamTinkerLaunch*. `steamtinkerlaunch otr blah blah` will never come from anywhere except someone wanting to run the `otr` command, but `steamtinkerlaunch waitforexitandrun /run/media/gaben/otr/` could conceivably be a path, so we *don't* account for those kinds of cases.

In other words:
- On `master`, `steamtinkerlaunch otr --exe="steamapps/common"` would incorrectly detect this as a game start process from Steam.
- With this PR, because we explicitly check if `$1` is `otr` (or `onetimerun`), we skip this command from being interpreted as a game launch and pass directly to `commandline "$@"` to run this command.

There is no reason why _all_ custom commands shouldn't be exluded, other than it would take time to add them all, and most won't encounter this issue.

<hr>

I did some testing with Proton games and native Linux games and it seems to work fine.

TODO:
- [x] Further testing, as this touches game start code
    - [x] Test more native titles with SLR
    - [x] Test native titles without SLR
    - [x] Test more Proton titles with SLR
    - [x] Test Proton titles without SLR
- [ ] Potentially add more commands to this list
- [x] Version bump