### PR TITLE
Custom Command: Add logging for native custom commands

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240618-1 (improve-customcmd-logging)"
+PROGVERS="v14.0.20240619-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -7183,6 +7183,11 @@ function extProtonRun {
 
 		# TODO pass "$EXTPROGRAMARGS" to programs running with Wine as well(?)
 		# TODO refactor a bit to be a little cleaner if possible
+		# TODO it should be possible to pass PROTON_LOG to these Proton commands, however this also requries SteamGameId to be set -- This is not defined outside of Steam AND inside of Steam it would conflict with an actual Game ID if used
+		#      if we want to use PROTON_LOG we need the ability to pass in PROTON_LOG=? and a custom SteamGameId that is only set for these program runs
+		#      i.e. a default SteamGameId could be `extProtonRun`, but launchCustomProg could pass `customcommand`.
+		#
+		#      This would be tricky to add, but would be nice to have!
 		CUSTPROGNAME="$( basename "$PROGRAM" )"
 		if [ "$MODE" == "F" ]; then  # Forked Proton/Wine 'normal' custom program
 			if [ -n "${RUNPROGARGS[0]}" ]; then

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240617-1"
+PROGVERS="v14.0.20240618-1 (improve-customcmd-logging)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -12928,20 +12928,20 @@ function launchCustomProg {
 					writelog "INFO" "${FUNCNAME[0]} - FORK_CUSTOMCMD is set to 1 - forking the custom program in background and continue"
 					if [ -n "${RUNEXTPROGRAMARGS[0]}" ]; then
 						writelog "INFO" "${FUNCNAME[0]} - \"${RUNEXTPROGRAMARGS[*]}\" \"${LACO}\" \"${RUNCUSTOMCMD_ARGS[*]}\""
-						(sleep "$FWAIT"; notiShow "$( strFix "$NOTY_CUSTPROG_FORKED_NATIVE" "$NATIVEPROGNAME" )"; "${RUNEXTPROGRAMARGS[@]}" "$LACO" "${RUNCUSTOMCMD_ARGS[@]}") &
+						(sleep "$FWAIT"; notiShow "$( strFix "$NOTY_CUSTPROG_FORKED_NATIVE" "$NATIVEPROGNAME" )"; "${RUNEXTPROGRAMARGS[@]}" "$LACO" "${RUNCUSTOMCMD_ARGS[@]}" 2>&1 | tee "$STLSHM/${FUNCNAME[0]}.log") &
 					else
 						writelog "INFO" "${FUNCNAME[0]} - \"${LACO}\" \"${RUNCUSTOMCMD_ARGS[*]}\""
-						(sleep "$FWAIT"; notiShow "$( strFix "$NOTY_CUSTPROG_FORKED_NATIVE" "$NATIVEPROGNAME" )"; "$LACO" "${RUNCUSTOMCMD_ARGS[@]}") &
+						(sleep "$FWAIT"; notiShow "$( strFix "$NOTY_CUSTPROG_FORKED_NATIVE" "$NATIVEPROGNAME" )"; "$LACO" "${RUNCUSTOMCMD_ARGS[@]}" 2>&1 | tee "$STLSHM/${FUNCNAME[0]}.log") &
 					fi
 				else  # Regular native executable
 					writelog "INFO" "${FUNCNAME[0]} - Starting native custom command regularly"
 					notiShow "$( strFix "$NOTY_CUSTPROG_REG_NATIVE" "$NATIVEPROGNAME" )"
 					if [ -n "${RUNEXTPROGRAMARGS[0]}" ]; then
 						writelog "INFO" "${FUNCNAME[0]} - \"${RUNEXTPROGRAMARGS[*]}\" \"${LACO}\" \"${RUNCUSTOMCMD_ARGS[*]}\""
-						"${RUNEXTPROGRAMARGS[@]}" "$LACO" "${RUNCUSTOMCMD_ARGS[@]}"
+						"${RUNEXTPROGRAMARGS[@]}" "$LACO" "${RUNCUSTOMCMD_ARGS[@]}" 2>&1 | tee "$STLSHM/${FUNCNAME[0]}.log"
 					else
 						writelog "INFO" "${FUNCNAME[0]} - \"${LACO}\" \"${RUNCUSTOMCMD_ARGS[*]}\""
-						"$LACO" "${RUNCUSTOMCMD_ARGS[@]}"
+						"$LACO" "${RUNCUSTOMCMD_ARGS[@]}" 2>&1 | tee "$STLSHM/${FUNCNAME[0]}.log"
 					fi
 				fi
 			fi


### PR DESCRIPTION
Adds logging for native custom commands, where the output (including any errors) will be stored under `STLSHMDIR` as `launchCustomProg.log`. Proton titles already had this loggiing in `extProtonRun`.

I would also like to find a way to log the `PROTON_LOG` for Proton custom commands. I'm not sure if it's possible, I think it is from looking at the Proton script - it should default to `steam-proton.log` if there is no `SteamGameId` in the environment, and I'm not sure if it will pick up the game AppID by default. If it does, we can temporarily unset this var before launching, and re-set it after launching as a hacky workaround if we really must.

We could even temporarily manipulate the value of `SteamGameId` to allow us to set the log file to something like `steam-<gameid>-customcmd.log` so that it is obvious the log is for a custom command pertaining to the given AppID.

Allowing a Proton log has the added benefit of being able to see some Proton-specific environment variables being set. The Proton script has a section where it tries to, for example, log information about the current Steam Linux Runtime. We _could_ re-implement this ourselves, but I'd rather hook into what Proton is currently doing.

All this also hinges on whether or not custom commands running with Proton can even use `PROTON_LOG`. When using `ONLY_CUSTOMCMD` in particular I'm not sure how many of our set environment variables (Proton-related or otherwise) get passed to custom commands, for example the ones in the per-game environment variable file, and the global one.

<hr>

This PR does accomplish one logging improvement, but further improvement to be able to give a Proton log since we run custom commands with Proton would be pretty nice.