### PR TITLE
Steam Deck: Bump innoextract version to 1.9-9

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240705-1 (steamos-3.6)"
+PROGVERS="v14.0.20241025-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20241023-1"
+PROGVERS="v14.0.20240705-1 (steamos-3.6)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -26517,7 +26517,7 @@ function checkSteamDeckDependencies {
 	# ARCHURL="https://archlinux.org/packages/community/x86_64"
 	ARCHARCHIVEURL="https://archive.archlinux.org/packages"
 
-	INNOEXTRACTVERS="1.9-8"
+	INNOEXTRACTVERS="1.9-9"
 	INNOEXTRACTFILE="$INNOEXTRACT-$INNOEXTRACTVERS-x86_64.pkg.tar.zst"
 	INNOEXTRACTURL="$ARCHARCHIVEURL/i/$INNOEXTRACT/$INNOEXTRACTFILE"
 


### PR DESCRIPTION
Fixes #1135.

SteamOS 3.6 updates the Arch snapshot so we need to do this again.

Opening as draft because SteamOS 3.6 is not yet in Stable.