### PR TITLE
Steam Paths: Attempt to set userdata path using MostRecent loginuser UserID

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240726-2"
+PROGVERS="v14.0.20240718-1 (use-mostrecent-loginuser-userdatadir)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -24345,7 +24345,7 @@ function generateSteamShortID {
 function fillLoginUsersCSV {
 	# Don't overwrite LoginUsersCSV file if it exists and is not blank, only re-create it if SHM dir is cleared
 	# The loginusers are not likely to change after the SHM dir is created so this is a bit more efficient
-	if [ -f "$LOGINUSERSCSV" ] && [ -s "$LOGINUSERCSV" ]; then
+	if [ -f "$LOGINUSERSCSV" ] && [ -s "$LOGINUSERSCSV" ]; then
 		writelog "INFO" "${FUNCNAME[0]} - '${LOGINUSERSCSV}' already exists -- Not re-creating"
 		return
 	fi
@@ -24355,10 +24355,9 @@ function fillLoginUsersCSV {
 
 	# Toplevel block in loginusers.vdf is "users", get all block names ("[0-9]+" with one hardcoded indent, because we know we only have 1 indent)
 	#
-	# TODO it would be nice to have a generic function to get all toplevel VDF block names like this, but =
+	# TODO it would be nice to have a generic function to get all toplevel VDF block names like this, but
 	# We can't know the pattern and would need to know how to differentiate between a blockname and a property name
-	# It just si happens for loginusers that it only contains blocks
-	LOGINUSERIDS=()
+	# It just so happens for loginusers that it only contains blocks
 	if [ -f "${LOGUVDF}" ]; then
 		writelog "INFO" "${FUNCNAME[0]} - Found loginusers file at '${LOGUVDF}' -- Will attempt to parse this file"
 		mapfile -t LOGINUSERLONGIDS < <(getVdfSection '"users"' "" "" "${LOGUVDF}" | grep -oP '^\t"[0-9]+"' | tr -d '\t"\ ')

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -650,8 +650,12 @@ function setSteamPaths {
 		if [ -f "$STLDEFGLOBALCFG" ] && grep -q "^STEAMUSERID=" "$STLDEFGLOBALCFG" ; then
 			STEAMUSERID="$(grep "^STEAMUSERID=" "$STLDEFGLOBALCFG" | grep -o "[[:digit:]]*")"
 			STUIDPATH="$SUSDA/$STEAMUSERID"
+
+			writelog "INFO" "${FUNCNAME[0]} - Parsing Steam UserID from global config as '$STEAMUSERID' -- STUIDPATH is now '$STUIDPATH'"
 		else
 			if [ -d "$SUSDA" ]; then
+				writelog "INFO" "${FUNCNAME[0]} - Trying to determine Steam UserID and userdata path"
+
 				STEAMUSERID=""
 				STUIDPATH=""
 
@@ -659,6 +663,7 @@ function setSteamPaths {
 				# fillLoginUsersCSV will fall back to taking the first userdata folder in the Steam userdata dir and will set it to MostRecent=1
 				# if it doesn't get any matches in loginusers.vdf, so we don't have to do the fallback here
 				if [ ! -f "$LOGINUSERSCSV" ]; then
+					writelog "INFO" "${FUNCNAME[0]} - Filling Users CSV"
 					fillLoginUsersCSV
 				fi
 
@@ -694,6 +699,11 @@ function setSteamPaths {
 				# Hopefully this never happens under normal usage... We should always be able to find the Steam User
 				if [ -z "${STEAMUSERID}" ] || [ -z "${STUIDPATH}" ]; then
 					writelog "WARN" "${FUNCNAME[0]} - Could not find any logged in Steam users in '$LOGINUSERSCSV' (are any users logged in?) - other variables depend on it, expect problems!" "E"
+				elif [ ! -d "${STUIDPATH}" ]; then
+					# If we were able to get the Most Recent Steam user but the userdata path for this user with this UserID does not actually exist, something has gone horribly wrong!
+					# One possible but unlikely scenario is that the MostRecent user in LognUsersCSV file was removed from the Steam Client, so the userdata path would no longer exist
+					# Users should remove /dev/shm/steamtinkerlaunch if the accounts or Steam Client config changes in any way so this would only be a temporary issue
+					writelog "WARN" "${FUNCNAME[0]} - Built Steam userdata path for User ID '${STEAMUSERID}' at path '${STUIDPATH}', but this path does not exist! This will probably cause problems!" "E"
 				fi
 			else
 				writelog "WARN" "${FUNCNAME[0]} - Steam '$USDA' directory not found, other variables depend on it - Expect problems" "E"
@@ -24351,7 +24361,7 @@ function fillLoginUsersCSV {
 	fi
 
 	# NOTE: For testing only
-	LOGUVDF="$HOME/.local/share/Steam/config/test_loginusers.vdf"
+	# LOGUVDF="$HOME/.local/share/Steam/config/test_loginusers.vdf"
 
 	# Toplevel block in loginusers.vdf is "users", get all block names ("[0-9]+" with one hardcoded indent, because we know we only have 1 indent)
 	#
@@ -24404,7 +24414,7 @@ function fillLoginUsersCSV {
 		# This value should really only ever be 0 or 1
 		LOGINUSERBLOCK="$( getVdfSection "${LOGINUSERLONGID}" "" "1" "${LOGUVDF}" )"
 		if [ -n "${LOGINUSERBLOCK}" ]; then
-			LOGINUSERMOSTRECENTVAL="$( getVdfSectionValue "${LOGINUSERBLOCK}" "MostRecent" "1" )"
+			LOGINUSERMOSTRECENTVAL="$( getVdfSectionValue "${LOGINUSERBLOCK}" "MostRecent" "1" | tr -d '"' )"
 
 			if [ -n "$LOGINUSERMOSTRECENTVAL" ]; then
 				LOGINUSERMOSTRECENT="$LOGINUSERMOSTRECENTVAL"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -115,6 +115,7 @@ VARSIN="$STLSHM/vars-in.txt"
 FUPDATE="$STLSHM/fupdate.txt"
 STPAVARS="$STLSHM/steampaths.txt"
 PROTONCSV="$STLSHM/ProtonCSV.txt"
+LOGINUSERSCSV="$STLSHM/LoginUsersCSV.txt"
 SWRF="$STLSHM/SWR.txt"
 UWRF="$STLSHM/UWR.txt"
 EWRF="$STLSHM/EWR.txt"
@@ -556,6 +557,7 @@ SCVDF="shortcuts.vdf"
 SRSCV="7/remote/$SCV"
 LCV="localconfig.vdf"
 COCOV="config/config.vdf"
+LUCOV="config/loginusers.vdf"
 SCSHVDF="screenshots.vdf"
 SCRSH="760/$SCSHVDF"
 LASTRUN="$LOGDIR/lastrun.txt"
@@ -633,6 +635,7 @@ function setSteamPaths {
 		setSteamPath "DEFSTEAMAPPS" "$SA"
 		setSteamPath "DEFSTEAMAPPSCOMMON" "$SAC"
 		setSteamPath "CFGVDF" "$COCOV"
+		setSteamPath "LOGUVDF" "$LUCOV"
 		setSteamPath "LFVDF" "$SA/$LIFOVDF"
 		setSteamPath "FAIVDF" "$AAVDF"
 		setSteamPath "PIVDF" "$APVDF"
@@ -649,10 +652,49 @@ function setSteamPaths {
 			STUIDPATH="$SUSDA/$STEAMUSERID"
 		else
 			if [ -d "$SUSDA" ]; then
-				# this works for 99% of all users, because most do have 1 steamuser on their system
-				# could pick most recent user (i.e. the current logged in user) from 'loginusers.vdf'
-				STUIDPATH="$(find "$SUSDA" -maxdepth 1 -type d -name "[1-9]*" | head -n1)"
-				STEAMUSERID="${STUIDPATH##*/}"
+				STEAMUSERID=""
+				STUIDPATH=""
+
+				# Try to set the path to the userdata folder (this contains grids, shortcuts.vdf, etc)
+				# fillLoginUsersCSV will fall back to taking the first userdata folder in the Steam userdata dir and will set it to MostRecent=1
+				# if it doesn't get any matches in loginusers.vdf, so we don't have to do the fallback here
+				if [ ! -f "$LOGINUSERSCSV" ]; then
+					fillLoginUsersCSV
+				fi
+
+				# Try to find the Steam Userdata folder and current Steam UserID based on generated LoginUsersCSV
+				# This allows us to select the currently logged in user as the Steam User we want to use, meaning
+				# we will use their userdata directory.
+				#
+				# If the currently logged in user changes we will then be able to use their userdata directory instead
+				# This allows us to use the correct userdata folder for the currently logged in user by default when
+				# there are multiple Steam user accounts logged into the same machine
+				#
+				# See also: https://github.com/sonic2kk/steamtinkerlaunch/issues/1140
+				while read -r loginuser; do
+					LOGINUSERCSVSHORTAID="$( echo "${loginuser}" | cut -d ';' -f2  )"
+					LOGINUSERCSVMOSTRECENT="$( echo "${loginuser}" | cut -d ';' -f3  )"
+
+					# if the loginuser loop variable is the MostRecent in loginusers.vdf, then:
+					# - set the current Steam User ID to the Short UserID
+					# - set the Steam userdata path to the base path + the Short UserID
+					if [ "${LOGINUSERCSVMOSTRECENT}" -eq 1 ]; then
+						STEAMUSERID="${LOGINUSERCSVSHORTAID}"
+						STUIDPATH="${SUSDA}/${STEAMUSERID}"
+
+						writelog "INFO" "${FUNCNAME[0]} - Found MostRecent Steam User '${STEAMUSERID}' from '${LOGINUSERSCSV}' - STUIDPATH is now '${STUIDPATH}'"
+						break
+					fi
+				done < "$LOGINUSERSCSV"
+
+				# Since fillLoginUsersCSV should handle the fallback for us, if we still have no matches,
+				# assume no users found at all, meaning no users are logged in!
+				# This will cause problems, so log a warning
+				#
+				# Hopefully this never happens under normal usage... We should always be able to find the Steam User
+				if [ -z "${STEAMUSERID}" ] || [ -z "${STUIDPATH}" ]; then
+					writelog "WARN" "${FUNCNAME[0]} - Could not find any logged in Steam users in '$LOGINUSERSCSV' (are any users logged in?) - other variables depend on it, expect problems!" "E"
+				fi
 			else
 				writelog "WARN" "${FUNCNAME[0]} - Steam '$USDA' directory not found, other variables depend on it - Expect problems" "E"
 			fi
@@ -24285,6 +24327,96 @@ function getGlobalSteamCompatToolInternalName {
 	fi
 }
 
+# Takes an signed 32bit integer and converts it to an unsigned 32bit integer
+# Steam uses this for Short UserIDs (userdata folder names) and Short Non-Steam Game AppIDs (Steam Shortcut Grid ID names)
+function generateSteamShortID {
+	echo $(( $1 & 0xFFFFFFFF ))
+}
+
+# Store loginusers data in CSV in in $STLSHM
+# We parse this info out of loginusers.vdf which stores has blocks grouped by Long UserID
+# We can convert down to the Short UserID from this.
+#
+# There should be a Short UserID folder in the SUSDA folder because each Steam User LongID in loginusers.vdf
+# should also have a corresponding Short UserID userdata folder.
+#
+# Columns for now are as follows (we can extend in future if we need to):
+# Long UserID,Short UserID,MostRecent
+function fillLoginUsersCSV {
+	# Don't overwrite LoginUsersCSV file if it exists and is not blank, only re-create it if SHM dir is cleared
+	# The loginusers are not likely to change after the SHM dir is created so this is a bit more efficient
+	if [ -f "$LOGINUSERSCSV" ] && [ -s "$LOGINUSERCSV" ]; then
+		writelog "INFO" "${FUNCNAME[0]} - '${LOGINUSERSCSV}' already exists -- Not re-creating"
+		return
+	fi
+
+	# NOTE: For testing only
+	LOGUVDF="$HOME/.local/share/Steam/config/test_loginusers.vdf"
+
+	# Toplevel block in loginusers.vdf is "users", get all block names ("[0-9]+" with one hardcoded indent, because we know we only have 1 indent)
+	#
+	# TODO it would be nice to have a generic function to get all toplevel VDF block names like this, but =
+	# We can't know the pattern and would need to know how to differentiate between a blockname and a property name
+	# It just si happens for loginusers that it only contains blocks
+	LOGINUSERIDS=()
+	if [ -f "${LOGUVDF}" ]; then
+		writelog "INFO" "${FUNCNAME[0]} - Found loginusers file at '${LOGUVDF}' -- Will attempt to parse this file"
+		mapfile -t LOGINUSERLONGIDS < <(getVdfSection '"users"' "" "" "${LOGUVDF}" | grep -oP '^\t"[0-9]+"' | tr -d '\t"\ ')
+	else
+		writelog "WARN" "${FUNCNAME[0]} - loginusers file at '${LOGUVDF}' does not exist! Will fall back to taking first Steam userdata folder as only login user"
+	fi
+
+	# If we couldn't parse loginusers.vdf, fall back to taking the first userdata folder we can find from the Steam userdata dir
+	if [ "${#LOGINUSERLONGIDS}" -eq 0 ]; then
+		writelog "WARN" "${FUNCNAME[0]} - Could not find any loginusers in '${LOGUVDF}', either loginusers file doesn't exist or did not return any parsable data -- Falling back to old method of grabbing first directory in '$SUSDA'"
+
+		# If we don't have loginusers.vdf, we don't have the long UserID because you can't get the Long UserID from the Short UserID
+		# The Short UserID uses bitwise AND which loses information
+		#
+		# In this case we just default to 1 (to avoid conflicting with the '0' userdata folder from Steam)
+		# This should be fine as we never need the Long UserID
+		LOGINUSERLONGID="1"
+
+		# We used to do this in setSteamPaths before we tried to parse MostRecent login user
+		LOGINUSERSHORTID="$( find "$SUSDA" -maxdepth 1 -type d -name "[1-9]*" | head -n1)"
+		LOGINUSERSHORTID="${LOGINUSERSHORTID##*/}"
+
+		# LOGINUSERLONGID="$( generateSteamShortID "${LOGINUSERLONGID}" )"
+		LOGINUSERMOSTRECENT="1"  # Default to 1 as we would only have one loginuser in this case
+
+		writelog "INFO" "${FUNCNAME[0]} - Writing loginuser '${LOGINUSERLONGID},${LOGINUSERSHORTID},${LOGINUSERMOSTRECENT}' to '${LOGINUSERSCSV}'"
+		printf '%s;%s;%s\n' "${LOGINUSERLONGID}" "${LOGINUSERSHORTID}" "${LOGINUSERMOSTRECENT}" > "${LOGINUSERSCSV}"
+
+		# Don't move onto below loop
+		return
+	fi
+
+	# If we could parse loginusers.vdf, assume valid data and iterate over it, storing it in LoginUsersCSV
+	for LOGINUSERLONGID in "${LOGINUSERLONGIDS[@]}"; do
+		writelog "INFO" "the id is ${LOGINUSERLONGID}"
+
+		LOGINUSERSHORTID="$( generateSteamShortID "${LOGINUSERLONGID}" )"
+		LOGINUSERMOSTRECENT="0"  # Default MostRecent to 0
+
+		# Check if user is most recent by trying to get the corresponding LongID block in loginusers.vdf
+		# and then picking out the MostRecent field
+		#
+		# If we find any value for MostRecent in the Long UserID block, store it in LOGINUSERMOSTRECENT
+		# This value should really only ever be 0 or 1
+		LOGINUSERBLOCK="$( getVdfSection "${LOGINUSERLONGID}" "" "1" "${LOGUVDF}" )"
+		if [ -n "${LOGINUSERBLOCK}" ]; then
+			LOGINUSERMOSTRECENTVAL="$( getVdfSectionValue "${LOGINUSERBLOCK}" "MostRecent" "1" )"
+
+			if [ -n "$LOGINUSERMOSTRECENTVAL" ]; then
+				LOGINUSERMOSTRECENT="$LOGINUSERMOSTRECENTVAL"
+			fi
+		fi
+
+		writelog "INFO" "${FUNCNAME[0]} - Writing loginuser '${LOGINUSERLONGID},${LOGINUSERSHORTID},${LOGINUSERMOSTRECENT}' to '${LOGINUSERSCSV}'"
+		printf '%s;%s;%s\n' "${LOGINUSERLONGID}" "${LOGINUSERSHORTID}" "${LOGINUSERMOSTRECENT}"
+	done >"$LOGINUSERSCSV"
+}
+
 function updateLocalConfigAppsValue {
 	# Add key for specific AppID to localconfig.vdf's Apps section, creating the initial 'Apps' section if it doesn't exist
 	# Used to set AllowOverlay and OpenVR when adding Non-Steam Games
@@ -24654,10 +24786,6 @@ function addNonSteamGame {
 		bigToLittleEndian "$( dec2hex "$1" )"
 	}
 
-	# Takes an signed 32bit integer and converts it to an unsigned 32bit integer
-	function generateShortcutGridAppId {
-		echo $(( $1 & 0xFFFFFFFF ))
-	}
 	## ----------
 	### END MAGIC APPID FUNCTIONS
 
@@ -24837,7 +24965,8 @@ function addNonSteamGame {
 	NOSTAIDVDF="$( generateShortcutVDFAppId "${NOSTAPPNAME}${NOSTEXEPATH}" )"  # signed integer AppID, stored in the VDF as hexidecimal - ex: -598031679
 	NOSTAIDVDFHEX="$( generateShortcutVDFHexAppId "$NOSTAIDVDF" )"  # 4byte little-endian hexidecimal of above 32bit signed integer, which we write out to the binary VDF - ex: c1c25adc
 	NOSTAIDVDFHEXFMT="\x$(awk '{$1=$1}1' FPAT='.{2}' OFS="\\\x" <<< "$NOSTAIDVDFHEX")"  # binary-formatted string hex of the above which we actually write out - ex: \xc1\xc2\x5a\xdc
-	NOSTAIDGRID="$( generateShortcutGridAppId "$NOSTAIDVDF" )"  # unsigned 32bit ingeger version of "$NOSTAIDVDF", which is used as the AppID for Steam artwork ("grids"), as well as for our shortcuts
+	# TODO test that this still works after renaming so that loginusers.vdf can use it
+	NOSTAIDGRID="$( generateSteamShortID "$NOSTAIDVDF" )"  # unsigned 32bit ingeger version of "$NOSTAIDVDF", which is used as the AppID for Steam artwork ("grids"), as well as for our shortcuts
 
 	writelog "INFO" "${FUNCNAME[0]} - === Adding new $NSGA ==="
 	writelog "INFO" "${FUNCNAME[0]} - Signed Integer Shortcut AppID: '${NOSTAIDVDF}'"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240718-1 (use-mostrecent-loginuser-userdatadir)"
+PROGVERS="v14.0.20240727-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -24974,7 +24974,6 @@ function addNonSteamGame {
 	NOSTAIDVDF="$( generateShortcutVDFAppId "${NOSTAPPNAME}${NOSTEXEPATH}" )"  # signed integer AppID, stored in the VDF as hexidecimal - ex: -598031679
 	NOSTAIDVDFHEX="$( generateShortcutVDFHexAppId "$NOSTAIDVDF" )"  # 4byte little-endian hexidecimal of above 32bit signed integer, which we write out to the binary VDF - ex: c1c25adc
 	NOSTAIDVDFHEXFMT="\x$(awk '{$1=$1}1' FPAT='.{2}' OFS="\\\x" <<< "$NOSTAIDVDFHEX")"  # binary-formatted string hex of the above which we actually write out - ex: \xc1\xc2\x5a\xdc
-	# TODO test that this still works after renaming so that loginusers.vdf can use it
 	NOSTAIDGRID="$( generateSteamShortID "$NOSTAIDVDF" )"  # unsigned 32bit ingeger version of "$NOSTAIDVDF", which is used as the AppID for Steam artwork ("grids"), as well as for our shortcuts
 
 	writelog "INFO" "${FUNCNAME[0]} - === Adding new $NSGA ==="


### PR DESCRIPTION
Fixes #1140.

## Overview
This PR builds the path to the `userdata` folder and selects the current Steam UserID based on the most recent user in Steam's `loginusers.vdf`. This VDF file has blocks for each Steam account currently logged into the Steam Client, and the one that was last logged into has its `"MostRecent"` field set to `"1"`. We store some information about this file into a CSV file and then read that in `setSteamPaths`. If the current row has `"MostRecent"` as `"1"` then we select that Short UserID row to build the path to the `userdata` folder.

This means instead of our current solution of picking the first result of the `find` command that matches our regex, we will try to use the Steam Account marked with `"MostRecent"` as `"1"` in `loginusers.vdf`. However if we cannot find or parse `loginusers.vdf` then we will fall back to using this `find` command as a last resort. This value is written into the CSV as the only user, meaning that in cases where we can find a Steam User, we will always write it into the CSV, so it should always have at least one row.

Alternatively, the `STEAMUSERID` variable can still be set in the global config to enforce a specific Steam Account, and all of this logic is ignored. This is not new logic, but is not something I knew before looking into this.

If we cannot parse `loginusers.vdf` to find the Most Recent user, then we log a warning and move on.

## Background
Steam has a `userdata` folder in its install location. This stores some user-specific Steam information, such as the `shortcuts.vdf` file and the `localconfig.vdf` file. We do use it for other things, but this the crux of #1140.

The `userdata` folder identifies users based on their UserID, specifically the Short UserID. So if a Short UserID is `12345`, then the `userdata` folder is `$SROOT/userdata/12345` (where `$SROOT` is the Steam install location).

Since the Steam Client can have multiple users, there may be multiple folders in this directory. However there are two we can ignore: `0` and `ac`. We don't need to care about these folders. Every UserID folder we care about will start with at least `1` and should always be at least two digits (i.e. there can't be a UserID of just `1`).

Since there can be multiple users, SteamTinkerLaunch just runs `find` in the `userdata` folder and picks the first result (probably the one with the smallest UserID). This works fine for most users because there is usually only one user account logged into the Steam Client on a PC at any given time... Or at least this has historically been true!

## Problem
Since we just pick the first userdata folder, if there are multiple accounts, this means that without setting `STEAMUSERID=` in the global config file, SteamTinkerLaunch may not use the right user account! If you have two accounts, Main and Alt, if Main's userdata folder is returned before Alt's, then by default SteamTinkerLaunch will always use Main's userdata folder.

This becomes a problem for a few reasons but one example is for adding Non-Steam Games. If you want to add a shortcut for Main and Alt, by default the first result of `find` will always be used. So without modifying the global config, shortcuts will always be added to whatever the first match with `find` is. 

## Solution
In order to determine which userdata folder we should use, we can check for the most recently logged in user in Steam's internal file that tracks some information about accounts currently logged into the Steam Client. This file is at `$SROOT/config/loginusers.vdf`. Each block in this file under the `users` section has a Long UserID, say `"1234567890"`. Inside this block is a field for each account called `"MostRecent"` which tracks the account which was last logged in to.

These Long UserIDs can be converted down into short UserIDs using `LongUserID & 0xFFFFFFFF`, identical to how we convert Non-Steam Game AppIDs. Converting this down from the Long UserID to the Short UserID can then give us the foldername. For example if `"1234567890"` converts down to `"12345"`, then we can get that user's `userdata` folder by going to `$SROOT/userdata/12345`.

By using this `loginusers.vdf` field we can effectively tell SteamTinkerLaunch to build the path to the `userdata` folder based on the currently logged in / last logged in user (last logged in if the user has the option to choose which account to sign into enabled at startup). So instead of hardcoding a default based on `find` or relying on `STEAMUSERID` in the  global config, we can dynamically choose the `userdata` folder.

In the event where we cannot get the `"MostRecent"` value (i.e. `loginusers.vdf` doesn't exist, or the VDF format changes, etc) then we fall back to using the `find` command and picking the first result from `userdata` which has only numbers is greater than `0`.

## Implementation
We have a new function called `fillLoginUsersCSV`, to parse through `loginusers.vdf`. Once we parse the information out, we write it to a file in `$STLSHM` called `LoginUsersCSV.txt` (as is convention). The reason we store it in a file is because this is not very likely to change, and it would be time consuming to fetch on each execution. So the trade-off is to cache the state of `loginusers.vdf` as it was when the file is generated for the first time. If the user logs into a different account, this file won't update. We do the same thing for some other files we parse including the `ProtonCSV` which is just as, if not moreso, I/O-bound.

The CSV file stores the Long UserID (where possible), Short UserID, and the value of `"MostRecent"`. The file might look something like this with multiple accounts.

```csv
1234567890,12345,1
0987654321,54321,0
4236927692,32265,0
```

The first row is the Most Recent account, and its userdata path would be `$SROOT/userdata/12345`.

This function works by getting the entire `"users"` block and then parsing out all the VDF sections that match the following:
- Start with a tab character
    - We can assume for the sections we want that they will always start with one tab, because we know the structure of this file already
    - We check that it *starts* with *one* tab to differentiate from values in the VDF sections, i.e. the `"MostRecent"` has two tabs followed by a number in quotes, as does `"timestamp"`.
- Contain only numbers inside of quotes

This allows us to match the start of VDF blocks inside of the file, which we can retrieve and parse out `"MostRecent"` from.

The function has a couple of other paths:
1. If the CSV already exists and is not empty, don't re-create it
2. If we cannot parse `loginusers.vdf` (i.e. it doesn't exist, or our functions cannot parse it for some reason like if the format ever changed), then we fall back to using the `find` function and picking the first one that gets returned.
    a This is still written into the CSV, and will be the only row written into the CSV. So if we fallback to `find` because we can't parse `loginusers.vdf`, we will still check the CSV to get the information we need in `setSteamPaths`, so that function only has to handle the paths of: if `STEAMUSERID` defined in global config, elif Steam user information in CSV file (doesn't care how the data got there, whether it's from `loginusers.vdf` or `find` command is irrelevant), else log warning that we couldn't get `userdata` folder.

Once we have this information in the CSV file, in `setSteamPaths` we try to parse this. If everything goes smoothly, the `userdata` path will be built dynamically based on the most recent user rather than always using the same result of the `find` command, which may pick the wrong result if multiple other Steam accounts are added.

This is all significantly more complex than what we had before, but should be more correct.

## Future Work
Since we now store all known Steam Users, we could in future parse out more information if known (such as display name). This would be useful for exposing on the Add Non-Steam Game GUI, where we could add a combobox entry to select which Steam User the `shortcuts.vdf` should be added for, defaulting to the current Steam User we selected. The dropdown should contain either the Account Name or Display Name

One problem with this is that we may not have an account name if we could not parse `loginusers.vdf`, so we would have to say "default" or find the account name in some other way.

We should be able to store the Display Name and Account Name, and on the Add Non-Steam Game GUI we can default to one of these name fields, but we should be able to accept the Long UserID, Short UserID, Account Name, and Display Name as possible arguments. Then when it gets passed to the commandline either by the user running it manually or from the GUI (i.e. if a user decides to enter their Account Name instead of Display Name) we should be able to search the CSV file and check if the entered value for the user matches any column in the current row.

If we cannot find the account mentioned, we should default to the Most Recent account.

That would mean, on top of this PR which would be a good default of selecting the current Steam User, a user can optionally define an account which the shortcuts can be added for. If they have a few different accounts this could be handy, or it could allow them to run the command multiple times to add the shortcut for multiple accounts.

<hr>

This PR is mostly ready, it just needs a bit more testing. In particular I want to make extra sure that the fallback works, as there was one report of VDF parsing not working for a user with `config.vdf`. So in cases where the parsing fails I want to make sure we can default so that we shouldn't end up with a case where we cannot find a Steam userdata directory if a valid one exists, and a valid one should always exist if at least one account is logged into Steam.

TODO:
- [ ] Further testing of fallback
- [ ] Some code cleanup
- [ ] Version bump