### PR TITLE
misc: Remove `VERSION.txt` and other text files from compatibility tool folder

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240828-1"
+PROGVERS="v14.0.20240821-1 (rermove-protonupqt-version-file)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -22171,15 +22171,17 @@ function CompatTool {
 	elif [ "$1" == "del" ]; then
 		if [ ! -d "$SCTS" ]; then
 			writelog "SKIP" "${FUNCNAME[0]} - Selected '$1' but '$SCTS' doesn't exist"
+			return
+		fi
+
+		rm "$SCTS/$PROGCMD" 2>/dev/null
+		# *.vdf is usually 'compatibilitytool.vdf', *.txt is usually 'VERSION.txt' created by ProtonUp-Qt
+		find "$SCTS" -maxdepth 1 -type f -name "*.vdf" -name "*.txt" -exec rm {} \;
+		rmdir "$SCTS"
+		if [ ! -d "$SCTS" ]; then
+			writelog "INFO" "${FUNCNAME[0]} - Removed '$SCTS' successfully" "E"
 		else
-			rm "$SCTS/$PROGCMD" 2>/dev/null
-			find "$SCTS" -maxdepth 1 -type f -name "*.vdf" -exec rm {} \;
-			rmdir "$SCTS"
-			if [ ! -d "$SCTS" ]; then
-				writelog "INFO" "${FUNCNAME[0]} - Removed '$SCTS' successfully" "E"
-			else
-				writelog "SKIP" "${FUNCNAME[0]} - Tried to carefully remove '$SCTS', but it still exists - any files inside '$SCTS'?" "E"
-			fi
+			writelog "SKIP" "${FUNCNAME[0]} - Tried to carefully remove '$SCTS', but it still exists - any files inside '$SCTS'?" "E"
 		fi
 	else
 		if [ ! -d "$SCTS" ]; then

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240821-2 (rermove-protonupqt-version-file)"
+PROGVERS="v14.0.20240829-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240821-1 (rermove-protonupqt-version-file)"
+PROGVERS="v14.0.20240821-2 (rermove-protonupqt-version-file)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -22176,7 +22176,7 @@ function CompatTool {
 
 		rm "$SCTS/$PROGCMD" 2>/dev/null
 		# *.vdf is usually 'compatibilitytool.vdf', *.txt is usually 'VERSION.txt' created by ProtonUp-Qt
-		find "$SCTS" -maxdepth 1 -type f -name "*.vdf" -name "*.txt" -exec rm {} \;
+		find "$SCTS" -maxdepth 1 -type f \( -name "*.vdf" -o -name "*.txt" \) -exec rm {} \;
 		rmdir "$SCTS"
 		if [ ! -d "$SCTS" ]; then
 			writelog "INFO" "${FUNCNAME[0]} - Removed '$SCTS' successfully" "E"


### PR DESCRIPTION
## Overview
This PR updates the logic when running `steamtinkerlaunch compat del` to also remove files ending with `.txt` when removing all files in the compatibility tool folder. This fixes the `compat del` command failing to remove the SteamTinkerLaunch folder in the `SROOT/compatibilitytools.d/SteamTinkerLaunch` because it does not account for removing the `VERSION.txt` file that may be generated by ProtonUp-Qt.

There are also a couple of style changes to remove some indentation.

## Background
When installing SteamTinkerLaunch with ProtonUp-Qt, ProtonUp-Qt will create a `VERSION.txt` file. It does this for various compatibility tools so that it can display the version on its UI (i.e. for SteamTinkerLaunch it might display `v14.0.20240728-1`, but Luxtorpeda it might display v70). ProtonUp-Qt creates this file in the directory of the compatibility tool, e.g. `~/.local/share/Steam/compatibilitytools.d/SteamTinkerLaunch`. The logic to add the `VERSION.txt` was added by me in DavidoTek/ProtonUp-Qt#174.

However this logic presents a problem. If a user installs SteamTinkerLaunch with ProtonUp-Qt, but then tries to remove the compatibility tool symlink themselves with `steamtinkerlaunch compat del`, this will fail because SteamTinkerLaunch is very careful about what files it removes, limiting only to the script file itself and files ending with `.vdf` (such as `compatibiltiytool.vdf` manifest file created for and required by the Steam Client for all compatibility tools). Once it removes these files it then tries to remove its compatibility tool install folder, but it cannot do this if there are files still in the folder, which would be the case as SteamTinkerLaunch does not remove the `VERSION.txt` file created by ProtonUp-Qt.

## Solution
To fix this, we now remove the `VERSION.txt` file created by ProtonUp-Qt by adding an additional check to remove files ending with `.txt` to the `find` command. Alternatively we could have used something like `rm -rf` but the existing check is careful, and I wanted to preserve this (and it makes sense to be careful inside of the Steam folder).