### PR TITLE
Remove CompatTool add from setflatpak function

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -11315,7 +11315,7 @@ function setGameScopeVars {
 	function getGameScopeGeneralOpts {
 		# GameScope Show Resolution (corresponds to -W, -H options, uppercase) -- Actual GameScope window size -- Dropdown
 		if [ -z "$GSSHWRES" ]; then
-			if ! grep -qw "\-w" <<< "$GAMESCOPE_ARGS" || ! grep -qw "\-h" <<< "$GAMESCOPE_ARGS"; then
+			if ! grep -qw "\-W" <<< "$GAMESCOPE_ARGS" || ! grep -qw "\-H" <<< "$GAMESCOPE_ARGS"; then
 				GSSHWRES="1280x720"
 			else
 				GSSHWRES="$(tr ' ' '\n' <<< "$GAMESCOPE_ARGS" | grep -wA1 "\-W" | tail -n1)x$(tr ' ' '\n' <<< "$GAMESCOPE_ARGS" | grep -wA1 "\-H" | tail -n1)"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -26878,7 +26878,6 @@ function setflatpak {
 	if [ -n "$FLATPAK_ID" ] && [ "$FLATPAK_ID" == "com.valvesoftware.Steam" ]; then
 		writelog "INFO" "${FUNCNAME[0]} - seems like flatpak is used, because variable 'FLATPAK_ID' exists and points to 'com.valvesoftware.Steam'"
 		INFLATPAK=1
-		CompatTool "add" "$FPBIN/$PROGCMD"
 	else
 		writelog "INFO" "${FUNCNAME[0]} - started $PROGNAME from ${0}"
 	fi

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240727-1"
+PROGVERS="v14.0.20240828-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -153,7 +153,6 @@ F1ACTIONCG="bash -c setColGui"
 BTS="backup-timestamp"
 DUMMYBIN="echo"
 STLAIDSIZE="12"
-FPBIN="/app/utils/bin"
 INFLATPAK=0
 WDIB="wine-discord-ipc-bridge"
 FIXGAMESCOPE=0


### PR DESCRIPTION
It isn't necessary due to how the Flatpak STL works, and at this point in the setup `$SROOT` doesn't seem to have been set anyway, so it fails.

```
Wed Aug 28 15:27:44 BST 2024 INFO - setflatpak - seems like flatpak is used, because variable 'FLATPAK_ID' exists and points to 'com.valvesoftware.Steam'
Wed Aug 28 15:27:44 BST 2024 SKIP - CompatTool - Steam Home Dir '' not found!
```