### PR TITLE
GameScope: Fix blank `GSSHWRES` and `GSINTRES` displaying '`x`'

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -11351,8 +11351,8 @@ function setGameScopeVars {
 
 		# GameScope Internal Resolution (corresponds to -w, -h options, lowercase) -- Resolution that games see (defaults to 1280x720) -- Dropdown
 		# Although this is a combobox, we still use "num" as the `getGameScopeArg` type because we want numeric validation
-		GSINTRESARGWIDTH="$( getGameScopeArg "$GAMESCOPE_ARGS" "-W" "$GSINTRESARGWIDTH" "" "1280" "num")"
-		GSINTRESARGHEIGHT="$( getGameScopeArg "$GAMESCOPE_ARGS" "-H" "$GSINTRESARGHEIGHT" "" "720" "num")"
+		GSINTRESARGWIDTH="$( getGameScopeArg "$GAMESCOPE_ARGS" "-w" "$GSINTRESARGWIDTH" "" "1280" "num")"
+		GSINTRESARGHEIGHT="$( getGameScopeArg "$GAMESCOPE_ARGS" "-h" "$GSINTRESARGHEIGHT" "" "720" "num")"
 
 		GSINTRES="${GSINTRESARGWIDTH}x${GSINTRESARGHEIGHT}"
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240829-3 (gamescope-use-getgamescopearg-for-gsshwres-gsintres)"
+PROGVERS="v14.0.20240831-1 (gamescope-use-getgamescopearg-for-gsshwres-gsintres)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -11985,7 +11985,8 @@ function GameScopeGui {
 						if [ "$GSHDLS" == "TRUE" ]                                      ; then  GAMESCOPE_ARGS="${GAMESCOPE_ARGS} --headless"; fi
 						### ADVANCED OPTIONS END ###
 
-						GAMESCOPE_ARGS="${GAMESCOPE_ARGS} --"
+						# Remove trailing whitespace and append '--'
+						GAMESCOPE_ARGS="${GAMESCOPE_ARGS# } --"
 
 						writelog "INFO" "${FUNCNAME[0]} - Saving configured GAMESCOPE_ARGS '$GAMESCOPE_ARGS' into '$STLGAMECFG'"
 						touch "$FUPDATE"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240831-1 (gamescope-use-getgamescopearg-for-gsshwres-gsintres)"
+PROGVERS="v14.0.20240903-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240829-2 (gamescope-use-getgamescopearg-for-gsshwres-gsintres)"
+PROGVERS="v14.0.20240829-3 (gamescope-use-getgamescopearg-for-gsshwres-gsintres)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -11825,19 +11825,25 @@ function GameScopeGui {
 
 						# Build the GameScope arguments string
 						unset GAMESCOPE_ARGS
+						GAMESCOPE_ARGS=""
+						
+						# Internal width/height (-w, -h) broken out from string like '1280x720'
+						# NOTE: In future if `GSINTW` is blank but `GSINTH` is set, we could calculate a corresponding 16:9 width like GameScope does
 						GSINTW1="${GSINTRES%x*}"
 						GSINTW="${GSINTW1%%-*}"
 						GSINTH1="${GSINTRES#*x}"
 						GSINTH="${GSINTH1%%-*}"
-						GAMESCOPE_ARGS="-w ${GSINTW} -h ${GSINTH}"
 
+						# Show width/height (-W, -H) broken out from string like '1280x720'
+						# NOTE: In future if `GSINTW` is blank but `GSINTH` is set, we could calculate a corresponding 16:9 width like GameScope does
 						GSSHWW1="${GSSHWRES%x*}"
 						GSSHWW="${GSSHWW1%%-*}"
 						GSSHWH1="${GSSHWRES#*x}"
 						GSSHWH="${GSSHWH1%%-*}"
-						GAMESCOPE_ARGS="${GAMESCOPE_ARGS} -W ${GSSHWW} -H ${GSSHWH}"
 
 						### GENERAL OPTIONS ###
+						if [ -n "$GSINTW" ] && [ -n "$GSINTH" ]                         ; then  GAMESCOPE_ARGS="${GAMESCOPE_ARGS} -w ${GSINTW} -h ${GSINTH}"; fi
+						if [ -n "$GSSHWW" ] && [ -n "$GSSHWH" ]                         ; then  GAMESCOPE_ARGS="${GAMESCOPE_ARGS} -W ${GSSHWW} -H ${GSSHWH}"; fi
 						if [ "$GSFLR" -eq "$GSFLR" ] 2>/dev/null                        ; then  GAMESCOPE_ARGS="${GAMESCOPE_ARGS} -r ${GSFLR}"; fi
 						if [ "$GSFLU" -eq "$GSFLU" ] 2>/dev/null                        ; then  GAMESCOPE_ARGS="${GAMESCOPE_ARGS} -o ${GSFLU}"; fi
 						if [ "$GSFS" == "TRUE" ]                                        ; then  GAMESCOPE_ARGS="${GAMESCOPE_ARGS} -f"; fi

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240831-1"
+PROGVERS="v14.0.20240829-1 (gamescope-use-getgamescopearg-for-gsshwres-gsintres)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -11294,41 +11294,70 @@ function setGameScopeVars {
 		ARGTYPE="${6,,}"  # e.g. "chk", "cb", etc (matches Yad widget types mostly)
 
 		# Set values for undefined arguments
-		if [ -z "$VAR" ]; then
-			if grep -qw "$FLAG" <<< "$ARGS"; then
-				if [[ $ARGTYPE =~ "cb" ]] || [[ $ARGTYPE =~ "num" ]]; then
-					# Get the value given to the argument as the enabled/selected value, e.g. get '2' from '-U 2' if we passed '-U'
-					tr ' ' '\n' <<< "$ARGS" | grep -wA1 "$FLAG" | tail -n1
-				elif [[ $ARGTYPE =~ "path" ]] || [[ $ARGTYPE =~ "txt" ]]; then
-					# Get value given to arguments with two dashes, like `--`
-					echo "$ARGS" | sed 's:--:\n--:g' | grep -wA1 "$FLAG" | sed "s:${UNESCAPED_FLAG}::g;s:-:\n-:g" | head -n1 | xargs
-				else
-					echo "$TRUEVAL"
-				fi
+		if [ -n "$VAR" ]; then
+			return
+		fi
+
+		# If the flag is not in the args string, return the default value for display purposes
+		if ! grep -qw "$FLAG" <<< "$ARGS"; then
+			echo "$DEFVAL"
+			return
+		fi
+
+		if [[ $ARGTYPE =~ "cb" ]] || [[ $ARGTYPE =~ "num" ]]; then
+			# Get the value given to the argument as the enabled/selected value, e.g. get '2' from '-U 2' if we passed '-U'
+			# If the value does not contain only numbers (with or without decimals) then this will be blank and we return the default value 'DEFVAL'
+			#
+			# If we get passed an invalid GameScope commandline argument where a flag that is supposed to be followed by a NUMBER is not,
+			# we could end up returning the next argument, e.g. `-s -f` would return `-s` if we didn't include the `grep -P`
+			# Using the `grep -P` we filter out potential garbage returned by the rest of the parsing.
+			#
+			# We are most likely to encounter problems without this `grep -P` when it comes to the `GSINTRES` and `GSSHWRES`,
+			# as if these are blank we end up displaying 'x'.
+			#
+			# For comboboxes that can display text, we will just have to assume we are passed a valid string, as freetext comboboxes could contain
+			# anything and we cannot/should not try to assume what is valid for them in this way.
+			# This logic only exists to filter out non-numerical values for flags which expect to be given a numerical argument
+			#
+			# For more background, see: https://github.com/sonic2kk/steamtinkerlaunch/pull/1152#issuecomment-2316286429
+			GSPARSEDARGVAL="$( tr ' ' '\n' <<< "$ARGS" | grep -wA1 "$FLAG" | tail -n1 )"
+
+			# Don't validate parsed value for combobox, this is free-text and could be anything 
+			if ! [[ $ARGTYPE =~ "num" ]]; then
+				echo "$GSPARSEDARGVAL"
+				return
+			fi
+
+			# If we expect our flag to be followed by a numerical value (either integer or decimal), we need to make sure we actually return
+			# a numerical value, so the `grep` will ensure this
+			GSPARSEDARGNUMVAL="$( echo "${GSPARSEDARGVAL}" | grep -P "^([\d]+)(?:\.([\d]{1,2}?))?$" )"
+			if [ -n "${GSPARSEDARGNUMVAL}" ]; then
+				echo "$GSPARSEDARGNUMVAL"
 			else
 				echo "$DEFVAL"
 			fi
+		elif [[ $ARGTYPE =~ "path" ]] || [[ $ARGTYPE =~ "txt" ]]; then
+			# Get value given to arguments with two dashes, like `--`
+			echo "$ARGS" | sed 's:--:\n--:g' | grep -wA1 "$FLAG" | sed "s:${UNESCAPED_FLAG}::g;s:-:\n-:g" | head -n1 | xargs
+		else
+			echo "$TRUEVAL"
 		fi
 	}
 
 	function getGameScopeGeneralOpts {
-		# GameScope Show Resolution (corresponds to -W, -H options, uppercase) -- Actual GameScope window size -- Dropdown
-		if [ -z "$GSSHWRES" ]; then
-			if ! grep -qw "\-W" <<< "$GAMESCOPE_ARGS" || ! grep -qw "\-H" <<< "$GAMESCOPE_ARGS"; then
-				GSSHWRES="1280x720"
-			else
-				GSSHWRES="$(tr ' ' '\n' <<< "$GAMESCOPE_ARGS" | grep -wA1 "\-W" | tail -n1)x$(tr ' ' '\n' <<< "$GAMESCOPE_ARGS" | grep -wA1 "\-H" | tail -n1)"
-			fi
-		fi
+		# GameScope Show Resolution (corresponds to -W, -H options, uppercase) -- Actual GameScope window size (defaults to 1280x720) -- Dropdown
+		# Although this is a combobox, we still use "num" as the `getGameScopeArg` type because we want numeric validation
+		GSSHOWRESARGWIDTH="$( getGameScopeArg "$GAMESCOPE_ARGS" "-W" "$GSSHOWRESARGWIDTH" "" "1280" "num")"
+		GSSHOWRESARGHEIGHT="$( getGameScopeArg "$GAMESCOPE_ARGS" "-H" "$GSSHOWRESARGHEIGHT" "" "720" "num")"
 
-		# GameScope Internal Resolution (corresponds to -w, -h options, lowercase) -- Resolution that games see -- Dropdown
-		if [ -z "$GSINTRES" ]; then
-			if ! grep -qw "\-w" <<< "$GAMESCOPE_ARGS" || ! grep -qw "\-h" <<< "$GAMESCOPE_ARGS"; then
-				GSINTRES="1280x720"
-			else
-				GSINTRES="$(tr ' ' '\n' <<< "$GAMESCOPE_ARGS" | grep -wA1 "\-w" | tail -n1)x$(tr ' ' '\n' <<< "$GAMESCOPE_ARGS" | grep -wA1 "\-h" | tail -n1)"
-			fi
-		fi
+		GSSHWRES="${GSSHOWRESARGWIDTH}x${GSSHOWRESARGHEIGHT}"
+
+		# GameScope Internal Resolution (corresponds to -w, -h options, lowercase) -- Resolution that games see (defaults to 1280x720) -- Dropdown
+		# Although this is a combobox, we still use "num" as the `getGameScopeArg` type because we want numeric validation
+		GSINTRESARGWIDTH="$( getGameScopeArg "$GAMESCOPE_ARGS" "-W" "$GSINTRESARGWIDTH" "" "1280" "num")"
+		GSINTRESARGHEIGHT="$( getGameScopeArg "$GAMESCOPE_ARGS" "-H" "$GSINTRESARGHEIGHT" "" "720" "num")"
+
+		GSINTRES="${GSINTRESARGWIDTH}x${GSINTRESARGHEIGHT}"
 
 		# Default internal resolution to $NON ('none') if blank -- Ensures we don't pass invalid resolution to GameScope
 		if [ -z "$GSINTRES" ]; then  GSINTRES="$NON"; fi

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240829-1 (gamescope-use-getgamescopearg-for-gsshwres-gsintres)"
+PROGVERS="v14.0.20240829-2 (gamescope-use-getgamescopearg-for-gsshwres-gsintres)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -11307,7 +11307,14 @@ function setGameScopeVars {
 		if [[ $ARGTYPE =~ "cb" ]] || [[ $ARGTYPE =~ "num" ]]; then
 			# Get the value given to the argument as the enabled/selected value, e.g. get '2' from '-U 2' if we passed '-U'
 			# If the value does not contain only numbers (with or without decimals) then this will be blank and we return the default value 'DEFVAL'
-			#
+			GSPARSEDARGVAL="$( tr ' ' '\n' <<< "$ARGS" | grep -wA1 "$FLAG" | tail -n1 )"
+
+			# Don't validate parsed value for combobox, this is free-text and could be anything 
+			if ! [[ $ARGTYPE =~ "num" ]]; then
+				echo "$GSPARSEDARGVAL"
+				return
+			fi
+
 			# If we get passed an invalid GameScope commandline argument where a flag that is supposed to be followed by a NUMBER is not,
 			# we could end up returning the next argument, e.g. `-s -f` would return `-s` if we didn't include the `grep -P`
 			# Using the `grep -P` we filter out potential garbage returned by the rest of the parsing.
@@ -11320,16 +11327,6 @@ function setGameScopeVars {
 			# This logic only exists to filter out non-numerical values for flags which expect to be given a numerical argument
 			#
 			# For more background, see: https://github.com/sonic2kk/steamtinkerlaunch/pull/1152#issuecomment-2316286429
-			GSPARSEDARGVAL="$( tr ' ' '\n' <<< "$ARGS" | grep -wA1 "$FLAG" | tail -n1 )"
-
-			# Don't validate parsed value for combobox, this is free-text and could be anything 
-			if ! [[ $ARGTYPE =~ "num" ]]; then
-				echo "$GSPARSEDARGVAL"
-				return
-			fi
-
-			# If we expect our flag to be followed by a numerical value (either integer or decimal), we need to make sure we actually return
-			# a numerical value, so the `grep` will ensure this
 			GSPARSEDARGNUMVAL="$( echo "${GSPARSEDARGVAL}" | grep -P "^([\d]+)(?:\.([\d]{1,2}?))?$" )"
 			if [ -n "${GSPARSEDARGNUMVAL}" ]; then
 				echo "$GSPARSEDARGNUMVAL"


### PR DESCRIPTION
## Overview
When `GSSHWRES` or `GSINTRES` were left blank, this would result in the boxes displaying '`x`'. This was brought up in #1152, and some implementation discussion went on there. This is fixed by parsing the value for `-W`/`-H` and `-w`/`-h` using `getGameScopeArg`, and by refactoring `getGameScopeArg` to accommodate this.

This PR also flattens `getGameScopeArg` a bit as well, to reduce nesting and improve readibility.

## Background
The reason for this bug is that we were only checking if the width and height flags (`-w`/`-h`/`-W`/`-H`) were defined, but not if they contained values. We incorrectly assumed that if the flags were present they would also have values, which is not the case.

As a result, we would fall into the `else` block when setting these resolutions and run `GSINTRES="$(tr ' ' '\n' <<< "$GAMESCOPE_ARGS" | grep -wA1 "\-w" | tail -n1)x$(tr ' ' '\n' <<< "$GAMESCOPE_ARGS" | grep -wA1 "\-h" | tail -n1)"` and `GSSHWRES="$(tr ' ' '\n' <<< "$GAMESCOPE_ARGS" | grep -wA1 "\-W" | tail -n1)x$(tr ' ' '\n' <<< "$GAMESCOPE_ARGS" | grep -wA1 "\-H" | tail -n1)"`. However the logic to parse out the width and height would return garbage, because there was no numeric value to parse out. Instead, it would parse out the next flag after it, or if it was the last flag in the arguments list, it would just print that flag. So if we passed `-W` and `-H`, `GSSHWRES` would end up returning `-Hx-H`, because `-H` comes after `-W`, and `-H` is the last flag so for the height value it just returns itself.

This code snippet should illustrate the problem:
```bash
# This will return `-h`
GAMESCOPE_ARGS="-w -h"
tr ' ' '\n' <<< "$GAMESCOPE_ARGS" | grep -wA1 "\-w" | tail -n1)
```

The reason the dropdown would display `x` and not `-Hx-H` or `-hx-h` is because we have some logic to only display integers on this Yad UI element:

```bash
--field="$GUI_GSINTRES!$DESC_GSINTRES ('GSINTRES')":CBE "$(cleanDropDown "${GSINTRES//\"}" "$(printf "%s\n" "$("$XRANDR" --current | grep "[0-9]x" | awk '{print $1}' | grep "^[0-9]" | tr '\n' '!')")")" \
--field="$GUI_GSSHWRES!$DESC_GSSHWRES ('GSSHWRES')":CBE "$(cleanDropDown "${GSSHWRES//\"}" "$(printf "%s\n" "$("$XRANDR" --current | grep "[0-9]x" | awk '{print $1}' | grep "^[0-9]" | tr '\n' '!')")")" \
```

This is how we end up with `x`, that logic removes the `-Hx-H`/`-hx-h`.

## Solution
The fix is to ensure that when we're parsing the resolution values, we should ignore any values that are not numeric. So if we get, for example, `-H` as our value, we should assume this is invalid and fall back to the default `1280x720`. Even if one of the values is wrong, we should invalidate the entire resolution and default back.

In order to do this, I ended up with a messy solution that would be duplicated for both resolutions that we capture. A cleaner way would be to have a re-usable function, and ultimately that led me to deciding to use `getGameScopeArg` for this. Back when this was implemented during one of the GameScope refactors, I did not initially opt to use this for the GameScope resolutions as it was a bit tricky. However now it is possible and it worked out of the box by just using it as a drop-in replacement to capture the internal and show resolutions!

But sadly that victory was short lived and I found out `getGameScopeArg` has the same limitation as the existing logic, in that it also returned `x` (or actually, `-hx-h`/`-Hx-H`). It had the same behaviour as our existing logic. So `getGameScopeArg` needed a refactor.

The change I made was that when we're expecting `getGameScopeArg` to parse out a `NUM` value, we should check that the value we parse out is actually a number. Since this could be an integer value or a decimal value, we need to account for both. So we can use this regex to do so: `grep -P "^([\d]+)(?:\.([\d]{1,2}?))?$"`. If we apply this regex to the garbage output of `-w -h`, which will return `-h`, we will get an empty string. When we get this we can default to returning the default value, which is specified as `1280` for width and `720` for height when we call `getGameScopeArg`.

```bash
# GameScope Show Resolution (corresponds to -W, -H options, uppercase) -- Actual GameScope window size (defaults to 1280x720) -- Dropdown
# Although this is a combobox, we still use "num" as the `getGameScopeArg` type because we want numeric validation
GSSHOWRESARGWIDTH="$( getGameScopeArg "$GAMESCOPE_ARGS" "-W" "$GSSHOWRESARGWIDTH" "" "1280" "num")"
GSSHOWRESARGHEIGHT="$( getGameScopeArg "$GAMESCOPE_ARGS" "-H" "$GSSHOWRESARGHEIGHT" "" "720" "num")"

GSSHWRES="${GSSHOWRESARGWIDTH}x${GSSHOWRESARGHEIGHT}"

# GameScope Internal Resolution (corresponds to -w, -h options, lowercase) -- Resolution that games see (defaults to 1280x720) -- Dropdown
# Although this is a combobox, we still use "num" as the `getGameScopeArg` type because we want numeric validation
GSINTRESARGWIDTH="$( getGameScopeArg "$GAMESCOPE_ARGS" "-W" "$GSINTRESARGWIDTH" "" "1280" "num")"
GSINTRESARGHEIGHT="$( getGameScopeArg "$GAMESCOPE_ARGS" "-H" "$GSINTRESARGHEIGHT" "" "720" "num")"

GSINTRES="${GSINTRESARGWIDTH}x${GSINTRESARGHEIGHT}"
```

This change allows us to correctly handle cases where the width and height flag are given, but do not return numeric values (resolution can only be numeric). Refactoring this in `getGameScopeArg` allows us to re-use this function for setting the GameScope resolutions finally and also means anywhere else in the GameScope logic that may have been impacted by this will also benefit from this fix. (I don't think anywhere else was impacted, but it is still good to have this logic contained in one place).

## Remaining Work
Since this is a change to `getGameScopeArg` we need to make sure this fix works correctly. I did some testing before opening a PR and values for comboboxes and numeric values seem to still save correctly, but this will need extensive testing before it can be merged.

## Future Work
GameScope does allow you to simply pass the `-h` or `-H` flags, and it will calculate a 16:9 resolution based on the height alone (GameScope assumes 16:9 if not specified, which is why I am proposing that we default to 16:9 as well, to match GameScope behaviour). Perhaps in future in SteamTinkerLaunch we can check if we have a height value, and calculate an appropriate width if it is blank. We could do this by checking `if [ -z "${GSINTRESARGWIDTH}" ] && [ -n "${GSINTRESARGHEIGHT}" ]" and then assigning a width value to `GSINTRESARGWIDTH`.

This would really only be useful for users that manually enter a GameScope arguments string into the Game Menu or their Per-Game Config File, as `-h 1080 --` is valid and GameScope would recognise this, but SteamTinkerLaunch would not.

This potential future work would not really apply to the GameScope menu and would probably not benefit it in any significant way, unless `x1080` would actually parse out the height and store it but not the width. We could consider this in future though I suppose.

<hr>

The remaining work here is to test this thoroughly. It fixes the bug it set out to fix but we need to regression test :-)