### PR TITLE
Editor: Move `GLOBCUSTVARS` in to `EDITORCFGLIST` section to show in EDITOR menu

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -217,7 +217,6 @@ STLGAMEDIR="$STLCFGDIR/gamecfgs"
 STLGUIDIR="$STLCFGDIR/guicfgs"
 STLGAMEDIRID="$STLGAMEDIR/id"
 STLCUSTVARSDIR="$STLGAMEDIR/customvars"
-GLOBCUSTVARS="$STLCUSTVARSDIR/global-custom-vars.conf"
 STLGAMEDIRTI="$STLGAMEDIR/title"
 STLCOLLECTIONDIR="$STLCFGDIR/collections"
 STLREGDIR="$STLCFGDIR/regs"
@@ -502,6 +501,7 @@ STLMENUBLOCKCFG="$STLCFGDIR/$MENUBLOCK"
 #STARTEDITORCFGLIST
 STLDEFGLOBALCFG="$STLCFGDIR/global.conf"													# global config
 STLDEFGAMECFG="$STLCFGDIR/default_template.conf"											# the default config template used to create new per game configs - will be auto created if not found
+GLOBCUSTVARS="$STLCUSTVARSDIR/global-custom-vars.conf"										# global config file for user defined custom variables
 
 function setSDCfg {
 STLSDLCFG="$STLCFGDIR/steamdeck.conf"														# Steam Deck config

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240829-1"
+PROGVERS="v14.0.20240831-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"


### PR DESCRIPTION
A simple change which allows `global-custom-vars.conf` to show up in the EDITOR dialog.