### PR TITLE
Add some checks to `restoreOrgVars` on `startGame`

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7208,7 +7208,7 @@ function extProtonRun {
 		# Hopefully unsetting is safe and doesn't mean places that need the SLR will lose it from this 'unset'
 		if [ "$EXTPROTUSESLR" -eq 1 ]; then
 			writelog "INFO" "${FUNCNAME[0]} - EXTPROTUSESLR is '$EXTPROTUSESLR' -- Attempting to find and use SLR with extProtonRun"
-			
+
 			unset "${SLRCMD[@]}"
 			setSLRReap
 		fi
@@ -7782,7 +7782,7 @@ function getGameWindowPID {
 
 		return
 	fi
-	
+
 	MAXWAIT=20
 	COUNTER=0
 	TESTPID="$NON"
@@ -12971,7 +12971,7 @@ function launchCustomProg {
 					writelog "INFO" "${FUNCNAME[0]} - FORK_CUSTOMCMD is set to 1 - forking the custom program in background and continue"
 					extProtonRun "FC" "$LACO" "$CUSTOMCMD_ARGS" "" "${CUSTOMCMD_USESLR}"
 				elif [ "$ONLY_CUSTOMCMD" -eq 1 ] && [ -n "${FINALOUTCMD[*]}" ]; then
-					writelog "INFO" "${FUNCNAME[0]} - ONLY_CUSTOMCMD is set to 1 and we have some arguments in FINALOUTCMD - passing to extProtonRun to build a valid start command"	
+					writelog "INFO" "${FUNCNAME[0]} - ONLY_CUSTOMCMD is set to 1 and we have some arguments in FINALOUTCMD - passing to extProtonRun to build a valid start command"
 					extProtonRun "R" "$LACO" "$CUSTOMCMD_ARGS" "$FINALOUTCMD" "${CUSTOMCMD_USESLR}"  # extProtonRun will handle adding the FINALOUTCMD args to
 				else
 					extProtonRun "RC" "$LACO" "$CUSTOMCMD_ARGS" "" "${CUSTOMCMD_USESLR}"
@@ -13017,7 +13017,7 @@ function launchCustomProg {
 
 				writelog "INFO" "${FUNCNAME[0]} - Steam Linux Runtime enabled, attempting to fetch Steam Linux Runtime for native Custom Command"
 				# "2" is the FORCESLRTYPE, meaning we want to force to get the native SLR -- We do this in case we are trying to launch a native custom command with a Proton title
-				# In this case, setSLRReap is going to have the Proton SLR vars set from the game launch, so we need to force it here to use the native SLR 
+				# In this case, setSLRReap is going to have the Proton SLR vars set from the game launch, so we need to force it here to use the native SLR
 				setNonGameSLRReap "2"
 			fi
 
@@ -17859,7 +17859,7 @@ function prepareMO2 {
 }
 
 function createMO2SilentModeExeProfilesList {
-	# Get all of the ModOrganizer 2 executables launch configurations in the instance's INI 
+	# Get all of the ModOrganizer 2 executables launch configurations in the instance's INI
 	# The user can use this to override which 'moshortcut://' is launched in Silent Mode
 	MO2SILENTMODEEXEPROFILES="$NON"
 	MO2GAMES="$GLOBALMISCDIR/mo2games.txt"
@@ -20308,7 +20308,7 @@ function startGame {
 		writelog "INFO" "${FUNCNAME[0]} - ## STL LAUNCH COMMAND: '${RUNCMD[*]}'"
 		writelog "INFO" "${FUNCNAME[0]} - ## GAMESTART HERE ###"
 
-		restoreOrgVars # restore original LC_ and friends for the game as long as not set in custom-vars
+		restoreOrgVars
 
 		GRUNLOG="$STLGLLOGDIRID/${AID}.log"
 		if [ "$ISORIGIN" -eq 1 ]; then
@@ -25433,7 +25433,7 @@ function restoreOrgVars {
 
 		# Check if the envvar has been defined in a custom-vars conf file, if so don't restore it and continue
 		if grep -q "^${RESTOREVAR}" "$GLOBCUSTVARS" || grep -q "^${RESTOREVAR}" "$GAMECUSTVARS"; then
-			writelog "WARN" "${FUNCNAME[0]} - Not restoring '${RESTOREVAR}' to original value as it is defined in a custom-vars conf file"
+			writelog "WARN" "${FUNCNAME[0]} - Not restoring '${RESTOREVAR}' to original value as it is defined in a custom-vars conf file. This may potentially cause issues."
 
 			continue
 		fi

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -20308,7 +20308,7 @@ function startGame {
 		writelog "INFO" "${FUNCNAME[0]} - ## STL LAUNCH COMMAND: '${RUNCMD[*]}'"
 		writelog "INFO" "${FUNCNAME[0]} - ## GAMESTART HERE ###"
 
-		restoreOrgVars # restore original LC_ and friends for the game
+		restoreOrgVars "startGame" # restore original LC_ and friends for the game as long as not set in custom-vars
 
 		GRUNLOG="$STLGLLOGDIRID/${AID}.log"
 		if [ "$ISORIGIN" -eq 1 ]; then
@@ -25424,10 +25424,30 @@ function unsetSTLvars {
 
 function restoreOrgVars {
 	writelog "INFO" "${FUNCNAME[0]} - Restoring previously cleared Variables"
-	LD_PRELOAD="$ORG_LD_PRELOAD"
-	LD_LIBRARY_PATH="$ORG_LD_LIBRARY_PATH"
-	LC_ALL="$ORG_LC_ALL"
-	PATH="$ORG_PATH"
+
+	if [ "$1" == "startGame" ] && ( grep -q "^LD_PRELOAD=" "$GLOBCUSTVARS" || grep -q "^LD_PRELOAD=" "$GAMECUSTVARS" ); then
+		writelog "INFO" "${FUNCNAME[0]} - Not restoring 'LD_PRELOAD' before game launch as it is defined in custom variables"
+	else
+		LD_PRELOAD="$ORG_LD_PRELOAD"
+	fi
+
+	if [ "$1" == "startGame" ] && ( grep -q "^LD_LIBRARY_PATH=" "$GLOBCUSTVARS" || grep -q "^LD_LIBRARY_PATH=" "$GAMECUSTVARS" ); then
+		writelog "INFO" "${FUNCNAME[0]} - Not restoring 'LD_LIBRARY_PATH' before game launch as it is defined in custom variables"
+	else
+		LD_LIBRARY_PATH="$ORG_LD_LIBRARY_PATH"
+	fi
+
+	if [ "$1" == "startGame" ] && ( grep -q "^LC_ALL=" "$GLOBCUSTVARS" || grep -q "^LC_ALL=" "$GAMECUSTVARS" ); then
+		writelog "INFO" "${FUNCNAME[0]} - Not restoring 'LC_ALL' before game launch as it is defined in custom variables"
+	else
+		LC_ALL="$ORG_LC_ALL"
+	fi
+
+	if [ "$1" == "startGame" ] && ( grep -q "^PATH=" "$GLOBCUSTVARS" || grep -q "^PATH=" "$GAMECUSTVARS" ); then
+		writelog "INFO" "${FUNCNAME[0]} - Not restoring 'PATH' before game launch as it is defined in custom variables"
+	else
+		PATH="$ORG_PATH"
+	fi
 }
 
 function rmOldLog {

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240903-2"
+PROGVERS="v14.0.20240904-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -20308,7 +20308,7 @@ function startGame {
 		writelog "INFO" "${FUNCNAME[0]} - ## STL LAUNCH COMMAND: '${RUNCMD[*]}'"
 		writelog "INFO" "${FUNCNAME[0]} - ## GAMESTART HERE ###"
 
-		restoreOrgVars "startGame" # restore original LC_ and friends for the game as long as not set in custom-vars
+		restoreOrgVars # restore original LC_ and friends for the game as long as not set in custom-vars
 
 		GRUNLOG="$STLGLLOGDIRID/${AID}.log"
 		if [ "$ISORIGIN" -eq 1 ]; then
@@ -25423,31 +25423,23 @@ function unsetSTLvars {
 }
 
 function restoreOrgVars {
-	writelog "INFO" "${FUNCNAME[0]} - Restoring previously cleared Variables"
+	writelog "INFO" "${FUNCNAME[0]} - Restoring previously cleared environment variables"
 
-	if [ "$1" == "startGame" ] && ( grep -q "^LD_PRELOAD=" "$GLOBCUSTVARS" || grep -q "^LD_PRELOAD=" "$GAMECUSTVARS" ); then
-		writelog "INFO" "${FUNCNAME[0]} - Not restoring 'LD_PRELOAD' before game launch as it is defined in custom variables"
-	else
-		LD_PRELOAD="$ORG_LD_PRELOAD"
-	fi
+	STLRESTOREVARS=( "LD_PRELOAD" "LD_LIBRARY_PATH" "LC_ALL" "PATH" )
+	for RESTOREVAR in "${STLRESTOREVARS[@]}"; do
 
-	if [ "$1" == "startGame" ] && ( grep -q "^LD_LIBRARY_PATH=" "$GLOBCUSTVARS" || grep -q "^LD_LIBRARY_PATH=" "$GAMECUSTVARS" ); then
-		writelog "INFO" "${FUNCNAME[0]} - Not restoring 'LD_LIBRARY_PATH' before game launch as it is defined in custom variables"
-	else
-		LD_LIBRARY_PATH="$ORG_LD_LIBRARY_PATH"
-	fi
+		# e.g. 'ORG_LD_PRELOAD' for 'LD_PRELOAD' on first iteration of the loop
+		BUILTORGVARNAME="\$ORG_${RESTOREVAR}"
 
-	if [ "$1" == "startGame" ] && ( grep -q "^LC_ALL=" "$GLOBCUSTVARS" || grep -q "^LC_ALL=" "$GAMECUSTVARS" ); then
-		writelog "INFO" "${FUNCNAME[0]} - Not restoring 'LC_ALL' before game launch as it is defined in custom variables"
-	else
-		LC_ALL="$ORG_LC_ALL"
-	fi
+		# Check if the envvar has been defined in a custom-vars conf file, if so don't restore it and continue
+		if grep -q "^${RESTOREVAR}" "$GLOBCUSTVARS" || grep -q "^${RESTOREVAR}" "$GAMECUSTVARS"; then
+			writelog "WARN" "${FUNCNAME[0]} - Not restoring '${RESTOREVAR}' to original value as it is defined in a custom-vars conf file"
 
-	if [ "$1" == "startGame" ] && ( grep -q "^PATH=" "$GLOBCUSTVARS" || grep -q "^PATH=" "$GAMECUSTVARS" ); then
-		writelog "INFO" "${FUNCNAME[0]} - Not restoring 'PATH' before game launch as it is defined in custom variables"
-	else
-		PATH="$ORG_PATH"
-	fi
+			continue
+		fi
+
+		eval "${RESTOREVAR}=\"${BUILTORGVARNAME}\""
+	done
 }
 
 function rmOldLog {

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -25333,13 +25333,19 @@ function closeSTL {
 # main:#################
 
 function saveOrgVars {
+	# TODO resolve the unused warnings by dynamically assigning the variables like we do in 'restoreOrgVars'
+
 	writelog "INFO" "${FUNCNAME[0]} - Storing some original variables to restore them later" "P"
 
 	env | grep "=" | sort -o "$VARSIN"
 
+	# shellcheck disable=2034
 	ORG_LD_PRELOAD="$LD_PRELOAD"
+	# shellcheck disable=2034
 	ORG_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
+	# shellcheck disable=2034
 	ORG_LC_ALL="$LC_ALL"
+	# shellcheck disable=2034
 	ORG_PATH="$PATH"
 }
 


### PR DESCRIPTION
My tentative and ugly attempt at fixing #1158 

Simply when we're in `startGame` check the relevant custom-vars to see if any of the envvars that would normally be reset to original values are defined, and just don't reset them.

Probably needs more testing to be safe, but so far so good.

I wasted so much time on this :crying_cat_face: 