### PR TITLE
Generic Gamescope session tweaks

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240917-1-genericfy-steamdedeckt"
+PROGVERS="v14.0.20240920-1-genericfy-steamdedeckt"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -4953,7 +4953,7 @@ function updateThisWinTemplate {
 }
 
 function updateWinRes {
-	if [ -z "$SAVESETSIZE" ] || [ "$ONSTEAMDECK" -eq 1 ]; then
+	if [ -z "$SAVESETSIZE" ] || [ "$FIXGAMESCOPE" -eq 1 ]; then
 		SAVESETSIZE=0
 	fi
 
@@ -10593,7 +10593,10 @@ function listScreenRes {
 
 function setInitWinXY {
 	DEFRESSHM="$STLSHM/defres.txt"
+	SCRW="$(getScreenRes w)"
+	SCRH="$(getScreenRes h)"
 	if [ -f "$DEFRESSHM" ] ; then
+
 		loadCfg "$DEFRESSHM" X
 		writelog "INFO" "${FUNCNAME[0]} - Using '${WINX}x${WINY}' from config '$DEFRESSHM'"
 	else
@@ -10601,12 +10604,14 @@ function setInitWinXY {
 			WINX="1280"
 			WINY="800"
 		else
-			SCRW="$(getScreenRes w)"
-			SCRH="$(getScreenRes h)"
-			WINX=$(( SCRW * 3 / 4))
-			WINY=$(( SCRH * 3 / 4))
+			if [ "$FIXGAMESCOPE" -eq 1 ];then
+				WINX="$SCRW"
+				WINY="$SCRH"
+			else
+				WINX=$(( SCRW * 3 / 4))
+				WINY=$(( SCRH * 3 / 4))
+			fi
 		fi
-
 		{
 		echo "WINX=\"$WINX\""
 		echo "WINY=\"$WINY\""
@@ -26622,7 +26627,7 @@ function installFilesSteamDeck {
 
 function steamdedeckt {
 # Differentiate between Steam Game Mode and Desktop Mode on Steam Deck
-if grep -q "generate-drm-mode" <<< "$(pgrep -a "$GAMESCOPE")"; then
+if grep -qi "steam" <<< "$(pgrep -a "$GAMESCOPE")"; then
 	writelog "INFO" "${FUNCNAME[0]} - Detected '$GAMESCOPE' running 'forced' - assuming we're running in Steam Game Mode"
 	FIXGAMESCOPE=1
 else 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -26623,9 +26623,46 @@ function installFilesSteamDeck {
 }
 
 function steamdedeckt {
+# Differentiate between Game Mode and Desktop Mode on Steam Deck
+if grep -q "generate-drm-mode" <<< "$(pgrep -a "$GAMESCOPE")"; then
+	writelog "INFO" "${FUNCNAME[0]} - Detected '$GAMESCOPE' running 'forced' - assuming we're running in Game Mode"
+	FIXGAMESCOPE=1
+else if [ -f "/sys/class/dmi/id/sys_vendor" ] && grep -q "Valve" "/sys/class/dmi/id/sys_vendor"; then
+	writelog "INFO" "${FUNCNAME[0]} - Did not detect a running '$GAMESCOPE' process - assuming we're running in Desktop Mode"
+	SMALLDESK=1
+fi
+writelog "INFO" "${FUNCNAME[0]} - Set 'FIXGAMESCOPE' to '$FIXGAMESCOPE'"
+writelog "INFO" "${FUNCNAME[0]} - Set 'SMALLDESK' to '$SMALLDESK'"
+	
+if [ -f "/sys/class/dmi/id/sys_vendor" ] && grep -q "Valve" "/sys/class/dmi/id/sys_vendor"; then
+	ONSTEAMDECK=1
+	GTKCSSFILE="$HOME/.config/gtk-3.0/gtk.css"
+	if [ ! -f "$GTKCSSFILE" ] ; then
+		writelog "SKIP" "${FUNCNAME[0]} - '$GTKCSSFILE' does not exist - skipping"
+	else
+		if grep -q "scrollbar" "$GTKCSSFILE"; then
+			writelog "SKIP" "${FUNCNAME[0]} - found a scrollbar entry in '$GTKCSSFILE'"
+		else
+			writelog "INFO" "${FUNCNAME[0]} - backup '$GTKCSSFILE' to '${GTKCSSFILE}_ORIGNAL'"
+			cp "$GTKCSSFILE" "${GTKCSSFILE}_ORIGNAL"
+			# NOTE: This styles most, but not all, UI elements on Steam Deck
+			# It makes the scrollbar wider and easier to grab, and it adds a right margin so UI elements aren't covered by the scollbar
+			# However currently the UI is not as uniform on Steam Deck, because file choosers and text fields don't have this margin
+			# PRs are welcome to apply styling to these elements :-)
+			writelog "INFO" "${FUNCNAME[0]} - adding bigger scrollbar and customising some other UI elements using '$GTKCSSFILE'"
+			{
+				echo ".scrollbar.vertical slider,"
+				echo "scrollbar.vertical slider {"
+				echo "min-width: 15px;"
+				echo "}"
+				echo "spinbutton, combobox button {"
+				echo "margin-right: 20px;"
+				echo "}"
+			} >> "$GTKCSSFILE"
+		fi
+	fi	
+fi
 	if [ -f "/etc/os-release" ] && grep -q "steamdeck" "/etc/os-release"; then
-		ONSTEAMDECK=1
-
 		export STEAMDECKWASUPDATE=0
 		export STEAMDECKDIDINSTALL=1
 		export STEAMDECKSTEAMRUN=0  # Stores if we're running STL when Steam opens on Steam Deck
@@ -26651,16 +26688,6 @@ function steamdedeckt {
 			STLICON="$SCRIPTDIR/misc/steamtinkerlaunch.svg"
 		fi
 		export NOTYARGS="-i $STLICON -a $PROGNAME"
-
-		# Differentiate between Game Mode and Desktop Mode on Steam Deck
-		if grep -q "generate-drm-mode" <<< "$(pgrep -a "$GAMESCOPE")"; then
-			writelog "INFO" "${FUNCNAME[0]} - Detected '$GAMESCOPE' running 'forced' - assuming we're running in Game Mode"
-			FIXGAMESCOPE=1
-		else
-			writelog "INFO" "${FUNCNAME[0]} - Did not detect a running '$GAMESCOPE' process - assuming we're running in Desktop Mode"
-
-			SMALLDESK=1
-		fi
 
 		writelog "INFO" "${FUNCNAME[0]} - Set 'FIXGAMESCOPE' to '$FIXGAMESCOPE'"
 		writelog "INFO" "${FUNCNAME[0]} - Set 'SMALLDESK' to '$SMALLDESK'"
@@ -26711,34 +26738,6 @@ function steamdedeckt {
 			if [ "$INFLATPAK" -eq 0 ]; then
 				notiShow "$NOTY_STEAMDECK_ADDCOMPAT" "X"
 				CompatTool "add" "$PREFIX/$PROGCMD" >/dev/null
-			fi
-
-			GTKCSSFILE="$HOME/.config/gtk-3.0/gtk.css"
-
-			if [ ! -f "$GTKCSSFILE" ] ; then
-				writelog "SKIP" "${FUNCNAME[0]} - '$GTKCSSFILE' does not exist - skipping"
-			else
-				if grep -q "scrollbar" "$GTKCSSFILE"; then
-					writelog "SKIP" "${FUNCNAME[0]} - found a scrollbar entry in '$GTKCSSFILE'"
-				else
-					writelog "INFO" "${FUNCNAME[0]} - backup '$GTKCSSFILE' to '${GTKCSSFILE}_ORIGNAL'"
-					cp "$GTKCSSFILE" "${GTKCSSFILE}_ORIGNAL"
-
-					# NOTE: This styles most, but not all, UI elements on Steam Deck
-					# It makes the scrollbar wider and easier to grab, and it adds a right margin so UI elements aren't covered by the scollbar
-					# However currently the UI is not as uniform on Steam Deck, because file choosers and text fields don't have this margin
-					# PRs are welcome to apply styling to these elements :-)
-					writelog "INFO" "${FUNCNAME[0]} - adding bigger scrollbar and customising some other UI elements using '$GTKCSSFILE'"
-					{
-						echo ".scrollbar.vertical slider,"
-						echo "scrollbar.vertical slider {"
-						echo "min-width: 15px;"
-						echo "}"
-						echo "spinbutton, combobox button {"
-						echo "margin-right: 20px;"
-						echo "}"
-					} >> "$GTKCSSFILE"
-				fi
 			fi
 		else
 			writelog "INFO" "${FUNCNAME[0]} - Seems like we're being run by Steam here, not doing any installation steps"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -26247,35 +26247,33 @@ function steamdeckClose {
 }
 
 function steamdeckBeforeGame {
-	if [ "$ONSTEAMDECK" -eq 1 ]; then
-		if [ "$FIXGAMESCOPE" -eq 1 ]; then
-			writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Steam Game Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"
-			writelog "INFO" "${FUNCNAME[0]} - Force-enabling DXVK_HDR=1 for Steam Deck Game Mode, allows HDR support for Steam Deck OLED and HDR displays attached to Steam Deck"
+	if [ "$FIXGAMESCOPE" -eq 1 ]; then
+		writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Steam Game Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"
+		writelog "INFO" "${FUNCNAME[0]} - Force-enabling DXVK_HDR=1 for Steam Game Mode, allows HDR support for Steam Deck OLED and HDR displays attached to Steam Deck"
 
-			# Override config value without updating the stored value itself, to preserve compatibility with Desktop Mode
-			export DXVK_HDR=1
-		else
-			writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Desktop Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"
-		fi
+		# Override config value without updating the stored value itself, to preserve compatibility with Desktop Mode
+		export DXVK_HDR=1
+	else if[ "$ONSTEAMDECK" -eq 1]; then
+		writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Desktop Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"
+	fi
 
-		if [ "$USEGAMESCOPE" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
-			writelog "SKIP" "${FUNCNAME[0]} - Disabling own GameScope on SteamDeck Steam Game Mode" "X"
-			USEGAMESCOPE=0
-		else
-			writelog "INFO" "${FUNCNAME[0]} - Allowing GameScope enabled on SteamDeck in Desktop Mode" "X"
-		fi
+	if [ "$USEGAMESCOPE" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
+		writelog "SKIP" "${FUNCNAME[0]} - Disabling own GameScope on SteamDeck Steam Game Mode" "X"
+		USEGAMESCOPE=0
+	else
+		writelog "INFO" "${FUNCNAME[0]} - Allowing GameScope enabled on SteamDeck in Desktop Mode" "X"
+	fi
 
-		if [ "$USEGAMEMODERUN" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
-			writelog "SKIP" "${FUNCNAME[0]} - Disabling own Feral GameMode tool (gamemoderun) on SteamDeck Steam Game Mode" "X"
-			USEGAMEMODERUN=0
-		else
-			writelog "INFO" "${FUNCNAME[0]} - Allowing Feral GameMode tool (gamemoderun) enabled on SteamDeck in Desktop Mode" "X"
-		fi
+	if [ "$USEGAMEMODERUN" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
+		writelog "SKIP" "${FUNCNAME[0]} - Disabling own Feral GameMode tool (gamemoderun) on SteamDeck Steam Game Mode" "X"
+		USEGAMEMODERUN=0
+	else
+		writelog "INFO" "${FUNCNAME[0]} - Allowing Feral GameMode tool (gamemoderun) enabled on SteamDeck in Desktop Mode" "X"
+	fi
 
-		if [ -n "$STLCTLID" ] && [ "$STLCTLID" != "$PLACEHOLDERAID" ]; then
-			writelog "INFO" "${FUNCNAME[0]} - Loading controller configuration for the current game via 'steam steam://forceinputappid/$AID'"
-			steam steam://forceinputappid/"$AID"
-		fi
+	if [ -n "$STLCTLID" ] && [ "$STLCTLID" != "$PLACEHOLDERAID" ]; then
+		writelog "INFO" "${FUNCNAME[0]} - Loading controller configuration for the current game via 'steam steam://forceinputappid/$AID'"
+		steam steam://forceinputappid/"$AID"
 	fi
 }
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -155,7 +155,10 @@ DUMMYBIN="echo"
 STLAIDSIZE="12"
 INFLATPAK=0
 WDIB="wine-discord-ipc-bridge"
-FIXGAMESCOPE=0
+GAMESCOPESESS=0
+GAMESCOPESESSX=0
+GAMESCOPESESSY=0
+GAMESCOPESESSCMD=""
 SMALLDESK=0
 VTX_DOTNET_ROOT="c:\\Program Files\\dotnet\\\\"
 STLQUIET=0
@@ -774,7 +777,7 @@ function OpenWikiPage {
 	if [ -n "$WIKURL" ]; then
 		if [ "$ONSTEAMDECK" -eq 1 ]; then
 			# Only open wiki on Steam Deck Game Mode
-			if [ "$FIXGAMESCOPE" -eq 0 ]; then
+			if [ "$GAMESCOPESESS" -eq 0 ]; then
 				writelog "INFO" "${FUNCNAME[0]} - Opening wiki URL '$WIKURL' using xdg-open on Steam Deck since Yad AppImage does not have WebKit support"
 				"$XDGO" "$WIKURL"
 			else
@@ -2056,10 +2059,27 @@ function pollWinRes {
 	POSY=0
 	unset COLCOUNT
 
-	if [ "$ONSTEAMDECK" -eq 1 ]; then
-		SCREENRES="1280x800"
-		WINX=1280
-		WINY=800
+	if [ "$GAMESCOPESESS" -eq 1 ]; then
+		# Get the GameScope command from pgrep
+		GAMESCOPESESSCMD="$( pgrep -a "$GAMESCOPE" | head -n1 )"
+				
+		writelog "INFO" "${FUNCNAME[0]} - GameScope Session CMD from pgrep is '${GAMESCOPESESSCMD}'"
+		# ...
+		# There should probably be some check here where if there is no found GameScope start command to bail out
+		# ...
+		
+		# 1280 and 720 are defaults if no value is returned for width and height respectively.
+		# We could replace these defaults with whatever the autodetected width and height variable is.
+		#
+		# Variable names can be whatever you want, just make sure the name you assign and the name in the argument match
+		GAMESCOPESESSX="$( getGameScopeArg "$GAMESCOPESESSCMD" "-W" "$GAMESCOPESESSX" "" "1280" "num")"
+		GAMESCOPESESSY="$( getGameScopeArg "$GAMESCOPESESSCMD" "-H" "$GAMESCOPESESSY" "" "720" "num")"
+		
+		writelog "INFO" "${FUNCNAME[0]} - GameScope resolution from pgrep is '${GAMESCOPESESSX}x${GAMESCOPESESSY}'"
+		
+		SCREENRES="${GAMESCOPESESSX}x${GAMESCOPESESSY}"
+		WINX="$GAMESCOPESESSX"
+		WINY="$GAMESCOPESESSY"
 		setGeom
 	else
 		SCREENRES="$(getScreenRes r)"
@@ -2067,7 +2087,7 @@ function pollWinRes {
 
 	if [ -z "$SCREENRES" ]; then  SCREENRES="any"; fi
 
-	if [ "$FIXGAMESCOPE" -eq 0 ]; then  # skip this if FIXGAMESCOPE is 1 - so for now only if running in GameMode
+	if [ "$GAMESCOPESESS" -eq 0 ]; then  # skip this if GAMESCOPESESS is 1 - so for now only if running in GameMode
 		TEMPL="template"
 		GAMEGUICFG="$STLGUIDIR/$SCREENRES/${AID}/${TITLE}.conf"
 		TEMPLGUICFG="$STLGUIDIR/$SCREENRES/${TEMPL}/${TITLE}.conf"
@@ -2118,7 +2138,7 @@ function pollWinRes {
 	CURGUICFG="$GAMEGUICFG"
 	export CURGUICFG="$CURGUICFG"
 
-	if [ "$FIXGAMESCOPE" -eq 0 ]; then
+	if [ "$GAMESCOPESESS" -eq 0 ]; then
 		updateWinRes "$TITLE" "$GAMEGUICFG" "$TEMPLGUICFG" &
 	fi
 }
@@ -4209,7 +4229,7 @@ function saveCfg {
 }
 
 function notiShow {
-	if [ "$FIXGAMESCOPE" -eq 1 ]; then
+	if [ "$GAMESCOPESESS" -eq 1 ]; then
 		writelog "INFO" "${FUNCNAME[0]} - Skipping notifier on Steam Game Mode"
 		USENOTIFIER=0 # might avoid a 2nd try during this session
 	elif [ "$STLQUIET" -eq 1 ]; then
@@ -4953,7 +4973,7 @@ function updateThisWinTemplate {
 }
 
 function updateWinRes {
-	if [ -z "$SAVESETSIZE" ] || [ "$FIXGAMESCOPE" -eq 1 ]; then
+	if [ -z "$SAVESETSIZE" ] || [ "$GAMESCOPESESS" -eq 1 ]; then
 		SAVESETSIZE=0
 	fi
 
@@ -5431,7 +5451,7 @@ function openTrayIcon {
 		loadCfg "$STLGAMECFG"
 	fi
 
-	if [ "$FIXGAMESCOPE" -eq 1 ]; then
+	if [ "$GAMESCOPESESS" -eq 1 ]; then
 		writelog "SKIP" "${FUNCNAME[0]} - Skipping TrayIcon on Steam Game Mode" "X"
 	else
 		if [ -z "$YADTRAYPID" ] && [ "$USETRAYICON" -eq 1 ]; then
@@ -10600,17 +10620,12 @@ function setInitWinXY {
 		loadCfg "$DEFRESSHM" X
 		writelog "INFO" "${FUNCNAME[0]} - Using '${WINX}x${WINY}' from config '$DEFRESSHM'"
 	else
-		if [ "$ONSTEAMDECK" -eq 1 ]; then
-			WINX="1280"
-			WINY="800"
+		if [ "$GAMESCOPESESS" -eq 1 ];then
+			WINX="$GAMESCOPESESSX"
+			WINY="$GAMESCOPESESSY"
 		else
-			if [ "$FIXGAMESCOPE" -eq 1 ];then
-				WINX="$SCRW"
-				WINY="$SCRH"
-			else
-				WINX=$(( SCRW * 3 / 4))
-				WINY=$(( SCRH * 3 / 4))
-			fi
+			WINX=$(( SCRW * 3 / 4))
+			WINY=$(( SCRH * 3 / 4))
 		fi
 		{
 		echo "WINX=\"$WINX\""
@@ -12717,7 +12732,7 @@ function setCommandLaunchVars {
 
 	if [ "$USEGAMESCOPE" -eq 1 ]; then
 		if [ "$USEMANGOAPP" -eq 1 ]; then
-			if [ "$FIXGAMESCOPE" -eq 1 ]; then
+			if [ "$GAMESCOPESESS" -eq 1 ]; then
 				writelog "SKIP" "${FUNCNAME[0]} - Disabling USEMANGOAPP variable in Steam Game Mode, because Steam Deck uses $MANGOAPP already by default"
 				USEMANGOAPP=0
 			else
@@ -26251,26 +26266,26 @@ function steamdeckClose {
 }
 
 function steamdeckBeforeGame {
-	if [ "$FIXGAMESCOPE" -eq 1 ]; then
-		writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Steam Game Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"
+	if [ "$GAMESCOPESESS" -eq 1 ]; then
+		writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Steam Game Mode (GAMESCOPESESS is '$GAMESCOPESESS')"
 		writelog "INFO" "${FUNCNAME[0]} - Force-enabling DXVK_HDR=1 for Steam Game Mode, allows HDR support for Steam Deck OLED and HDR displays attached to Steam Deck"
 
 		# Override config value without updating the stored value itself, to preserve compatibility with Desktop Mode
 		export DXVK_HDR=1
 	else 
 		if [ "$ONSTEAMDECK" -eq 1 ]; then
-			writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Desktop Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"
+			writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Desktop Mode (GAMESCOPESESS is '$GAMESCOPESESS')"
 		fi
 	fi
 
-	if [ "$USEGAMESCOPE" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
+	if [ "$USEGAMESCOPE" -eq 1 ] && [ "$GAMESCOPESESS" -eq 1 ]; then
 		writelog "SKIP" "${FUNCNAME[0]} - Disabling own GameScope on SteamDeck Steam Game Mode" "X"
 		USEGAMESCOPE=0
 	else
 		writelog "INFO" "${FUNCNAME[0]} - Allowing GameScope enabled on SteamDeck in Desktop Mode" "X"
 	fi
 
-	if [ "$USEGAMEMODERUN" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
+	if [ "$USEGAMEMODERUN" -eq 1 ] && [ "$GAMESCOPESESS" -eq 1 ]; then
 		writelog "SKIP" "${FUNCNAME[0]} - Disabling own Feral GameMode tool (gamemoderun) on SteamDeck Steam Game Mode" "X"
 		USEGAMEMODERUN=0
 	else
@@ -26629,14 +26644,14 @@ function steamdedeckt {
 # Differentiate between Steam Game Mode and Desktop Mode on Steam Deck
 if grep -qi "steam" <<< "$(pgrep -a "$GAMESCOPE")"; then
 	writelog "INFO" "${FUNCNAME[0]} - Detected '$GAMESCOPE' running 'forced' - assuming we're running in Steam Game Mode"
-	FIXGAMESCOPE=1
+	GAMESCOPESESS=1
 else 
 	if [ -f "/sys/class/dmi/id/sys_vendor" ] && grep -q "Valve" "/sys/class/dmi/id/sys_vendor"; then
 		writelog "INFO" "${FUNCNAME[0]} - Did not detect a running '$GAMESCOPE' process - assuming we're running in Desktop Mode"
 		SMALLDESK=1
 	fi
 fi
-writelog "INFO" "${FUNCNAME[0]} - Set 'FIXGAMESCOPE' to '$FIXGAMESCOPE'"
+writelog "INFO" "${FUNCNAME[0]} - Set 'GAMESCOPESESS' to '$GAMESCOPESESS'"
 writelog "INFO" "${FUNCNAME[0]} - Set 'SMALLDESK' to '$SMALLDESK'"
 	
 if [ -f "/sys/class/dmi/id/sys_vendor" ] && grep -q "Valve" "/sys/class/dmi/id/sys_vendor"; then
@@ -26694,7 +26709,7 @@ fi
 		fi
 		export NOTYARGS="-i $STLICON -a $PROGNAME"
 
-		writelog "INFO" "${FUNCNAME[0]} - Set 'FIXGAMESCOPE' to '$FIXGAMESCOPE'"
+		writelog "INFO" "${FUNCNAME[0]} - Set 'GAMESCOPESESS' to '$GAMESCOPESESS'"
 		writelog "INFO" "${FUNCNAME[0]} - Set 'SMALLDESK' to '$SMALLDESK'"
 
 		INTERNETCONNECTION=1

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240921-3-genericfy-steamdedeckt"
+PROGVERS="v14.0.20240921-4-genericfy-steamdedeckt"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -10612,9 +10612,7 @@ function listScreenRes {
 }
 
 function setInitWinXY {
-	DEFRESSHM="$STLSHM/defres.txt"
-	SCRW="$(getScreenRes w)"	
-	SCRH="$(getScreenRes h)"
+	DEFRESSHM="$STLSHM/defres.txt"	
 	if [ -f "$DEFRESSHM" ] ; then
 
 		loadCfg "$DEFRESSHM" X
@@ -10624,6 +10622,8 @@ function setInitWinXY {
 			WINX="$GAMESCOPESESSX"
 			WINY="$GAMESCOPESESSY"
 		else
+			SCRW="$(getScreenRes w)"
+			SCRH="$(getScreenRes h)"
 			WINX=$(( SCRW * 3 / 4))
 			WINY=$(( SCRH * 3 / 4))
 		fi

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240921-2-genericfy-steamdedeckt"
+PROGVERS="v14.0.20240921-3-genericfy-steamdedeckt"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -10613,6 +10613,8 @@ function listScreenRes {
 
 function setInitWinXY {
 	DEFRESSHM="$STLSHM/defres.txt"
+	SCRW="$(getScreenRes w)"	
+	SCRH="$(getScreenRes h)"
 	if [ -f "$DEFRESSHM" ] ; then
 
 		loadCfg "$DEFRESSHM" X

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -2067,7 +2067,7 @@ function pollWinRes {
 
 	if [ -z "$SCREENRES" ]; then  SCREENRES="any"; fi
 
-	if [ "$FIXGAMESCOPE" -eq 0 ]; then  # skip this if FIXGAMESCOPE is 1 - so for now only if running in GameMode on the Steam Deck
+	if [ "$FIXGAMESCOPE" -eq 0 ]; then  # skip this if FIXGAMESCOPE is 1 - so for now only if running in GameMode
 		TEMPL="template"
 		GAMEGUICFG="$STLGUIDIR/$SCREENRES/${AID}/${TITLE}.conf"
 		TEMPLGUICFG="$STLGUIDIR/$SCREENRES/${TEMPL}/${TITLE}.conf"
@@ -4209,8 +4209,8 @@ function saveCfg {
 }
 
 function notiShow {
-	if [ "$ONSTEAMDECK" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
-		writelog "INFO" "${FUNCNAME[0]} - Skipping notifier on SteamDeck Game Mode"
+	if [ "$FIXGAMESCOPE" -eq 1 ]; then
+		writelog "INFO" "${FUNCNAME[0]} - Skipping notifier on Game Mode"
 		USENOTIFIER=0 # might avoid a 2nd try during this session
 	elif [ "$STLQUIET" -eq 1 ]; then
 		USENOTIFIER=0
@@ -5431,8 +5431,8 @@ function openTrayIcon {
 		loadCfg "$STLGAMECFG"
 	fi
 
-	if [ "$ONSTEAMDECK" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
-		writelog "SKIP" "${FUNCNAME[0]} - Skipping TrayIcon on SteamDeck Game Mode" "X"
+	if [ "$FIXGAMESCOPE" -eq 1 ]; then
+		writelog "SKIP" "${FUNCNAME[0]} - Skipping TrayIcon on Game Mode" "X"
 	else
 		if [ -z "$YADTRAYPID" ] && [ "$USETRAYICON" -eq 1 ]; then
 			writelog "INFO" "${FUNCNAME[0]} - Opening trayIcon:" "X"
@@ -12712,14 +12712,13 @@ function setCommandLaunchVars {
 
 	if [ "$USEGAMESCOPE" -eq 1 ]; then
 		if [ "$USEMANGOAPP" -eq 1 ]; then
-			if [ "$ONSTEAMDECK" -eq 1 ]; then
-				if [ "$FIXGAMESCOPE" -eq 1 ]; then
-					writelog "SKIP" "${FUNCNAME[0]} - Disabling USEMANGOAPP variable in Steam Deck Game Mode, because Steam Deck uses $MANGOAPP already by default"
-					USEMANGOAPP=0
-				else
-					writelog "INFO" "${FUNCNAME[0]} - Allowing USEMANGOAPP variable in Steam Deck Desktop Mode"
-					USEMANGOAPP=1
-				fi
+			if [ "$FIXGAMESCOPE" -eq 1 ]; then
+				writelog "SKIP" "${FUNCNAME[0]} - Disabling USEMANGOAPP variable in Steam Deck Game Mode, because Steam Deck uses $MANGOAPP already by default"
+				USEMANGOAPP=0
+			else
+				writelog "INFO" "${FUNCNAME[0]} - Allowing USEMANGOAPP variable in Steam Deck Desktop Mode"
+				USEMANGOAPP=1
+			fi
 			else
 				writelog "SKIP" "${FUNCNAME[0]} - Not adding $GAMESCOPE to the game launch command, because $MANGOAPP is enabled, which triggers it automatically"
 				USEGAMESCOPE=0

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240904-1"
+PROGVERS="v14.0.20240917-1-genericfy-steamdedeckt"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -12732,7 +12732,6 @@ function setCommandLaunchVars {
 			GSC="$(command -v "$GAMESCOPE")"
 
 			gameScopeArgs "$GAMESCOPE_ARGS"  # Create GameScope args array - Is called twice because we call `setCommandLaunchVars` above and in `buildCustomCmdLaunch` it seems
-		fi
 	fi
 
 	# NOTE: Primerun and Zink both set ' __GLX_VENDOR_LIBRARY_NAME', so Zink has to go after Primerun as shown to activate correctly
@@ -26253,8 +26252,10 @@ function steamdeckBeforeGame {
 
 		# Override config value without updating the stored value itself, to preserve compatibility with Desktop Mode
 		export DXVK_HDR=1
-	else if[ "$ONSTEAMDECK" -eq 1]; then
-		writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Desktop Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"
+	else 
+		if [ "$ONSTEAMDECK" -eq 1 ]; then
+			writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Desktop Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"
+		fi
 	fi
 
 	if [ "$USEGAMESCOPE" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
@@ -26624,9 +26625,11 @@ function steamdedeckt {
 if grep -q "generate-drm-mode" <<< "$(pgrep -a "$GAMESCOPE")"; then
 	writelog "INFO" "${FUNCNAME[0]} - Detected '$GAMESCOPE' running 'forced' - assuming we're running in Steam Game Mode"
 	FIXGAMESCOPE=1
-else if [ -f "/sys/class/dmi/id/sys_vendor" ] && grep -q "Valve" "/sys/class/dmi/id/sys_vendor"; then
-	writelog "INFO" "${FUNCNAME[0]} - Did not detect a running '$GAMESCOPE' process - assuming we're running in Desktop Mode"
-	SMALLDESK=1
+else 
+	if [ -f "/sys/class/dmi/id/sys_vendor" ] && grep -q "Valve" "/sys/class/dmi/id/sys_vendor"; then
+		writelog "INFO" "${FUNCNAME[0]} - Did not detect a running '$GAMESCOPE' process - assuming we're running in Desktop Mode"
+		SMALLDESK=1
+	fi
 fi
 writelog "INFO" "${FUNCNAME[0]} - Set 'FIXGAMESCOPE' to '$FIXGAMESCOPE'"
 writelog "INFO" "${FUNCNAME[0]} - Set 'SMALLDESK' to '$SMALLDESK'"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240921-4-genericfy-steamdedeckt"
+PROGVERS="v14.0.20240922-2-genericfy-steamdedeckt"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -156,8 +156,9 @@ STLAIDSIZE="12"
 INFLATPAK=0
 WDIB="wine-discord-ipc-bridge"
 GAMESCOPESESS=0
-GAMESCOPESESSX=0
-GAMESCOPESESSY=0
+GAMESCOPESESSRES=1280x800
+GAMESCOPESESSX=1280
+GAMESCOPESESSY=800
 GAMESCOPESESSCMD=""
 SMALLDESK=0
 VTX_DOTNET_ROOT="c:\\Program Files\\dotnet\\\\"
@@ -2060,27 +2061,43 @@ function pollWinRes {
 	unset COLCOUNT
 
 	if [ "$GAMESCOPESESS" -eq 1 ]; then
-		# Get the GameScope command from pgrep
-		GAMESCOPESESSCMD="$( pgrep -a "$GAMESCOPE" | head -n1 )"
-				
-		writelog "INFO" "${FUNCNAME[0]} - GameScope Session CMD from pgrep is '${GAMESCOPESESSCMD}'"
-		# ...
-		# There should probably be some check here where if there is no found GameScope start command to bail out
-		# ...
-		
-		# 1280 and 720 are defaults if no value is returned for width and height respectively.
-		# We could replace these defaults with whatever the autodetected width and height variable is.
-		#
-		# Variable names can be whatever you want, just make sure the name you assign and the name in the argument match
-		GAMESCOPESESSX="$( getGameScopeArg "$GAMESCOPESESSCMD" "-W" "$GAMESCOPESESSX" "" "1280" "num")"
-		GAMESCOPESESSY="$( getGameScopeArg "$GAMESCOPESESSCMD" "-H" "$GAMESCOPESESSY" "" "720" "num")"
-		
-		writelog "INFO" "${FUNCNAME[0]} - GameScope resolution from pgrep is '${GAMESCOPESESSX}x${GAMESCOPESESSY}'"
-		
-		SCREENRES="${GAMESCOPESESSX}x${GAMESCOPESESSY}"
-		WINX="$GAMESCOPESESSX"
-		WINY="$GAMESCOPESESSY"
-		setGeom
+		GAMESCOPESESS_CONFIG_FILE="$HOME/.config/gamescope/modes.cfg"
+		if [ -f "$GAMESCOPESESS_CONFIG_FILE" ]; then
+			writelog "INFO" "${FUNCNAME[0]} - Found Gamecope Resolution config file at '${GAMESCOPESESS_CONFIG_FILE}'."
+			# Extract the resolution
+    		GAMESCOPESESSRES=$(awk -F '[:@]' '{print $2}' "$GAMESCOPESESS_CONFIG_FILE" | xargs)
+
+    		# Split the resolution into width and height
+    		IFS='x' read -r GAMESCOPESESSX GAMESCOPESESSY <<< "$GAMESCOPESESSRES"
+			writelog "INFO" "${FUNCNAME[0]} - GameScope Session Resolution from config file is '${GAMESCOPESESSRES}'"
+
+			SCREENRES="${GAMESCOPESESSRES}"
+			WINX="$GAMESCOPESESSX"
+			WINY="$GAMESCOPESESSY"
+			setGeom
+		else
+			# Get the GameScope command from pgrep
+			GAMESCOPESESSCMD="$( pgrep -a "$GAMESCOPE" | head -n1 )"
+					
+			writelog "INFO" "${FUNCNAME[0]} - GameScope Session CMD from pgrep is '${GAMESCOPESESSCMD}'"
+			# ...
+			# There should probably be some check here where if there is no found GameScope start command to bail out
+			# ...
+			
+			# 1280 and 720 are defaults if no value is returned for width and height respectively.
+			# We could replace these defaults with whatever the autodetected width and height variable is.
+			#
+			# Variable names can be whatever you want, just make sure the name you assign and the name in the argument match
+			GAMESCOPESESSX="$( getGameScopeArg "$GAMESCOPESESSCMD" "-W" "$GAMESCOPESESSX" "" "1280" "num")"
+			GAMESCOPESESSY="$( getGameScopeArg "$GAMESCOPESESSCMD" "-H" "$GAMESCOPESESSY" "" "720" "num")"
+			
+			writelog "INFO" "${FUNCNAME[0]} - GameScope resolution from pgrep is '${GAMESCOPESESSX}x${GAMESCOPESESSY}'"
+			
+			SCREENRES="${GAMESCOPESESSX}x${GAMESCOPESESSY}"
+			WINX="$GAMESCOPESESSX"
+			WINY="$GAMESCOPESESSY"
+			setGeom
+		fi
 	else
 		SCREENRES="$(getScreenRes r)"
 	fi
@@ -10612,7 +10629,7 @@ function listScreenRes {
 }
 
 function setInitWinXY {
-	DEFRESSHM="$STLSHM/defres.txt"	
+	DEFRESSHM="$STLSHM/defres.txt"
 	if [ -f "$DEFRESSHM" ] ; then
 
 		loadCfg "$DEFRESSHM" X
@@ -10627,6 +10644,7 @@ function setInitWinXY {
 			WINX=$(( SCRW * 3 / 4))
 			WINY=$(( SCRH * 3 / 4))
 		fi
+		
 		{
 		echo "WINX=\"$WINX\""
 		echo "WINY=\"$WINY\""
@@ -26641,7 +26659,9 @@ function installFilesSteamDeck {
 }
 
 function steamdedeckt {
-# Differentiate between Steam Game Mode and Desktop Mode on Steam Deck
+
+# Differentiate between Steam Game Mode and Desktop Mode on Steam Deck 
+# TODO: make the check less generic as right now it may match steam running in a nested gamescope session and not embedded
 if grep -qi "steam" <<< "$(pgrep -a "$GAMESCOPE")"; then
 	writelog "INFO" "${FUNCNAME[0]} - Detected '$GAMESCOPE' running 'forced' - assuming we're running in Steam Game Mode"
 	GAMESCOPESESS=1

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240920-1-genericfy-steamdedeckt"
+PROGVERS="v14.0.20240921-2-genericfy-steamdedeckt"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -10613,8 +10613,6 @@ function listScreenRes {
 
 function setInitWinXY {
 	DEFRESSHM="$STLSHM/defres.txt"
-	SCRW="$(getScreenRes w)"
-	SCRH="$(getScreenRes h)"
 	if [ -f "$DEFRESSHM" ] ; then
 
 		loadCfg "$DEFRESSHM" X

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -773,12 +773,12 @@ function OpenWikiPage {
 
 	if [ -n "$WIKURL" ]; then
 		if [ "$ONSTEAMDECK" -eq 1 ]; then
-			# Only open wiki on Steam Deck Steam Game Mode
+			# Only open wiki on Steam Deck Game Mode
 			if [ "$FIXGAMESCOPE" -eq 0 ]; then
 				writelog "INFO" "${FUNCNAME[0]} - Opening wiki URL '$WIKURL' using xdg-open on Steam Deck since Yad AppImage does not have WebKit support"
 				"$XDGO" "$WIKURL"
 			else
-				writelog "SKIP" "${FUNCNAME[0]} - Running in Steam Deck Steam Game Mode - Opening wiki page using xdg-open here may not work or may have undesired results - Skipping"
+				writelog "SKIP" "${FUNCNAME[0]} - Running in Steam Deck Game Mode - Opening wiki page using xdg-open here may not work or may have undesired results - Skipping"
 			fi
 		else
 			TITLE="${PROGNAME}-Wiki"
@@ -12713,7 +12713,7 @@ function setCommandLaunchVars {
 	if [ "$USEGAMESCOPE" -eq 1 ]; then
 		if [ "$USEMANGOAPP" -eq 1 ]; then
 			if [ "$FIXGAMESCOPE" -eq 1 ]; then
-				writelog "SKIP" "${FUNCNAME[0]} - Disabling USEMANGOAPP variable in Steam Deck Steam Game Mode, because Steam Deck uses $MANGOAPP already by default"
+				writelog "SKIP" "${FUNCNAME[0]} - Disabling USEMANGOAPP variable in Steam Game Mode, because Steam Deck uses $MANGOAPP already by default"
 				USEMANGOAPP=0
 			else
 				writelog "INFO" "${FUNCNAME[0]} - Allowing USEMANGOAPP variable in Steam Deck Desktop Mode"
@@ -26250,7 +26250,7 @@ function steamdeckBeforeGame {
 	if [ "$ONSTEAMDECK" -eq 1 ]; then
 		if [ "$FIXGAMESCOPE" -eq 1 ]; then
 			writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Steam Game Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"
-			writelog "INFO" "${FUNCNAME[0]} - Force-enabling DXVK_HDR=1 for Steam Deck Steam Game Mode, allows HDR support for Steam Deck OLED and HDR displays attached to Steam Deck"
+			writelog "INFO" "${FUNCNAME[0]} - Force-enabling DXVK_HDR=1 for Steam Deck Game Mode, allows HDR support for Steam Deck OLED and HDR displays attached to Steam Deck"
 
 			# Override config value without updating the stored value itself, to preserve compatibility with Desktop Mode
 			export DXVK_HDR=1

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -773,12 +773,12 @@ function OpenWikiPage {
 
 	if [ -n "$WIKURL" ]; then
 		if [ "$ONSTEAMDECK" -eq 1 ]; then
-			# Only open wiki on Steam Deck Game Mode
+			# Only open wiki on Steam Deck Steam Game Mode
 			if [ "$FIXGAMESCOPE" -eq 0 ]; then
 				writelog "INFO" "${FUNCNAME[0]} - Opening wiki URL '$WIKURL' using xdg-open on Steam Deck since Yad AppImage does not have WebKit support"
 				"$XDGO" "$WIKURL"
 			else
-				writelog "SKIP" "${FUNCNAME[0]} - Running in Steam Deck Game Mode - Opening wiki page using xdg-open here may not work or may have undesired results - Skipping"
+				writelog "SKIP" "${FUNCNAME[0]} - Running in Steam Deck Steam Game Mode - Opening wiki page using xdg-open here may not work or may have undesired results - Skipping"
 			fi
 		else
 			TITLE="${PROGNAME}-Wiki"
@@ -4210,7 +4210,7 @@ function saveCfg {
 
 function notiShow {
 	if [ "$FIXGAMESCOPE" -eq 1 ]; then
-		writelog "INFO" "${FUNCNAME[0]} - Skipping notifier on Game Mode"
+		writelog "INFO" "${FUNCNAME[0]} - Skipping notifier on Steam Game Mode"
 		USENOTIFIER=0 # might avoid a 2nd try during this session
 	elif [ "$STLQUIET" -eq 1 ]; then
 		USENOTIFIER=0
@@ -5432,7 +5432,7 @@ function openTrayIcon {
 	fi
 
 	if [ "$FIXGAMESCOPE" -eq 1 ]; then
-		writelog "SKIP" "${FUNCNAME[0]} - Skipping TrayIcon on Game Mode" "X"
+		writelog "SKIP" "${FUNCNAME[0]} - Skipping TrayIcon on Steam Game Mode" "X"
 	else
 		if [ -z "$YADTRAYPID" ] && [ "$USETRAYICON" -eq 1 ]; then
 			writelog "INFO" "${FUNCNAME[0]} - Opening trayIcon:" "X"
@@ -12713,7 +12713,7 @@ function setCommandLaunchVars {
 	if [ "$USEGAMESCOPE" -eq 1 ]; then
 		if [ "$USEMANGOAPP" -eq 1 ]; then
 			if [ "$FIXGAMESCOPE" -eq 1 ]; then
-				writelog "SKIP" "${FUNCNAME[0]} - Disabling USEMANGOAPP variable in Steam Deck Game Mode, because Steam Deck uses $MANGOAPP already by default"
+				writelog "SKIP" "${FUNCNAME[0]} - Disabling USEMANGOAPP variable in Steam Deck Steam Game Mode, because Steam Deck uses $MANGOAPP already by default"
 				USEMANGOAPP=0
 			else
 				writelog "INFO" "${FUNCNAME[0]} - Allowing USEMANGOAPP variable in Steam Deck Desktop Mode"
@@ -26249,8 +26249,8 @@ function steamdeckClose {
 function steamdeckBeforeGame {
 	if [ "$ONSTEAMDECK" -eq 1 ]; then
 		if [ "$FIXGAMESCOPE" -eq 1 ]; then
-			writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Game Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"
-			writelog "INFO" "${FUNCNAME[0]} - Force-enabling DXVK_HDR=1 for Steam Deck Game Mode, allows HDR support for Steam Deck OLED and HDR displays attached to Steam Deck"
+			writelog "INFO" "${FUNCNAME[0]} - Final Deck Check: Looks like we're in Steam Game Mode (FIXGAMESCOPE is '$FIXGAMESCOPE')"
+			writelog "INFO" "${FUNCNAME[0]} - Force-enabling DXVK_HDR=1 for Steam Deck Steam Game Mode, allows HDR support for Steam Deck OLED and HDR displays attached to Steam Deck"
 
 			# Override config value without updating the stored value itself, to preserve compatibility with Desktop Mode
 			export DXVK_HDR=1
@@ -26259,14 +26259,14 @@ function steamdeckBeforeGame {
 		fi
 
 		if [ "$USEGAMESCOPE" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
-			writelog "SKIP" "${FUNCNAME[0]} - Disabling own GameScope on SteamDeck Game Mode" "X"
+			writelog "SKIP" "${FUNCNAME[0]} - Disabling own GameScope on SteamDeck Steam Game Mode" "X"
 			USEGAMESCOPE=0
 		else
 			writelog "INFO" "${FUNCNAME[0]} - Allowing GameScope enabled on SteamDeck in Desktop Mode" "X"
 		fi
 
 		if [ "$USEGAMEMODERUN" -eq 1 ] && [ "$FIXGAMESCOPE" -eq 1 ]; then
-			writelog "SKIP" "${FUNCNAME[0]} - Disabling own Feral GameMode tool (gamemoderun) on SteamDeck Game Mode" "X"
+			writelog "SKIP" "${FUNCNAME[0]} - Disabling own Feral GameMode tool (gamemoderun) on SteamDeck Steam Game Mode" "X"
 			USEGAMEMODERUN=0
 		else
 			writelog "INFO" "${FUNCNAME[0]} - Allowing Feral GameMode tool (gamemoderun) enabled on SteamDeck in Desktop Mode" "X"
@@ -26622,9 +26622,9 @@ function installFilesSteamDeck {
 }
 
 function steamdedeckt {
-# Differentiate between Game Mode and Desktop Mode on Steam Deck
+# Differentiate between Steam Game Mode and Desktop Mode on Steam Deck
 if grep -q "generate-drm-mode" <<< "$(pgrep -a "$GAMESCOPE")"; then
-	writelog "INFO" "${FUNCNAME[0]} - Detected '$GAMESCOPE' running 'forced' - assuming we're running in Game Mode"
+	writelog "INFO" "${FUNCNAME[0]} - Detected '$GAMESCOPE' running 'forced' - assuming we're running in Steam Game Mode"
 	FIXGAMESCOPE=1
 else if [ -f "/sys/class/dmi/id/sys_vendor" ] && grep -q "Valve" "/sys/class/dmi/id/sys_vendor"; then
 	writelog "INFO" "${FUNCNAME[0]} - Did not detect a running '$GAMESCOPE' process - assuming we're running in Desktop Mode"


### PR DESCRIPTION
Steam Game Mode (also referred to as gamescope-session or steam-gamescope-session)
It is no longer limited to Steam OS.

This PR moves some of the  Steam Game Mode-specific tweaks out of the check for Steam OS (but still in the same function. I am not sure if I should put it elsewhere, but it made sense to me to leave it there)

I also made the sizing fixes apply to all Steam decks, not just Steam OS.

Not all of the Steam deck tweaks are desirable outside of Steam OS, even when still running on a Steam deck (mainly the dependencies stuff)


Basically, it comes down to


## non-steam deck hardware running some Steam OS-like distro (or  using something like https://aur.archlinux.org/packages/gamescope-session-steam-git)

- [x] Disable Tray indicator
- [x] Disable Notifyer
- [x] Disable Mangohud/ Mangopeel
- [x] Disable Gamescope Settings
- [x] Disable Feral Game Mode
- [x] Force ```DXVK_HDR=1```
- [x] Make sure YAD windows are sized correctly in Gamescope (rn its running as a tiny window; I think it may be because of FSR)
![2138610_20240917213731_1](https://github.com/user-attachments/assets/3aa96e11-98d5-4135-a478-764ae96885ec)


## Steam deck running some Steam OS like distro (ex bazzite)
### This should do everything we currently do for Steam deck running Steam OS minus the dependencies stuff

- [ ] Disable Tray indicator
- [ ] Disable Notifyer
- [ ] Disable Mangohud/ Mangopeel
- [ ] Disable Gamescope Settings
- [ ] Disable Feral Game Mode
- [ ] Force ```DXVK_HDR=1```
- [ ]  More sizing fixes fixes for specific for the Steam decks screen