### PR TITLE
lang: Don't create global config in `loadLanguage`

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20241003-1"
+PROGVERS="v14.0.20240930-1 (dont-create-globalconfig-paths-without-steamvars)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -2696,8 +2696,13 @@ function loadLanguage {
 	writelog "INFO" "${FUNCNAME[0]} - First load the default language '$STLDEFLANG' to make sure all variables are filled"
 	loadLangFile "$STLDEFLANG"
 
-	saveCfg "$STLDEFGLOBALCFG" X
-	loadCfg "$STLDEFGLOBALCFG" X
+	# Prevents loadLanguage from creating the global.conf too early when it may be missing values
+	# i.e. loadLanguage may be called before setSteamPaths, which can result in creating paths without the required Steam path variables set yet
+	#      This can happen with Luxtorpead, where the LUXTORPEDACMD may be written out before `setSteamPaths` has been called to set `STEAMCOMPATTOOL`
+	if [ -f "$STLDEFGLOBALCFG" ]; then
+		saveCfg "$STLDEFGLOBALCFG" X
+		loadCfg "$STLDEFGLOBALCFG" X
+	fi
 
 	writelog "INFO" "${FUNCNAME[0]} - Loading STLLANG from '$STLDEFGLOBALCFG'"
 

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240930-1 (dont-create-globalconfig-paths-without-steamvars)"
+PROGVERS="v14.0.20241003-2"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"


### PR DESCRIPTION
Fix #1177.

Don't attempt to save and load the global config in `loadLanguage` unless it exists.

Prevents `loadLanguage`, which is called very early, from creating the global config before `setSteamPaths` has a chance to define some paths that are needed to create the global config.

Most notably, this fixes Luxtorpeda and Roberta variables from being incorrect when created too early by `loadLanguage`, as this function creates the global config before `setSteamPaths` has a chance to define `STEAMCOMPATOOLS` which is needed in order to build a valid path for `LUXTORPEDACMD` and `ROBERTACMD`. SteamTinkerLaunch tries to auto-detect Luxtorpeda installations and this has not worked for probably the last 2 years or so, since `loadLanguage` created the global config too soon. However, Luxtorpeda could always be and still can be manually selected by the user, so the only breakage was for the auto-detection.

This may possibly fix other similar cases as well, where Steam paths are needed in the global config but it is created before paths exist.

This fix **will not** retroactively apply to global configs, as we don't know whether the variables are incorrectly generated by us or the user. Bad global configs will need re-generated.

<hr>

This PR needs some testing to ensure the `-f "$STLDEFGLOBALCFG"` check is safe. I think it is, but this will need a bit of further testing.