### PR TITLE
Luxtorpeda: Update default `LUXTORPEDACMD` path

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240930-1 (update-default-luxtorpeda-path)"
+PROGVERS="v14.0.20241003-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20240904-1"
+PROGVERS="v14.0.20240930-1 (update-default-luxtorpeda-path)"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -3141,7 +3141,7 @@ function setDefaultCfgValues {
 		if [ -z "$BOXTRONARGS" ]						; then	BOXTRONARGS="--wait-before-run"; fi
 		if [ -z "$ROBERTACMD" ]							; then	ROBERTACMD="$STEAMCOMPATOOLS/roberta/run-vm"; fi
 		if [ -z "$ROBERTAARGS" ]						; then	ROBERTAARGS="--wait-before-run"; fi
-		if [ -z "$LUXTORPEDACMD" ]						; then	LUXTORPEDACMD="$STEAMCOMPATOOLS/luxtorpeda/luxtorpeda"; fi
+		if [ -z "$LUXTORPEDACMD" ]						; then	LUXTORPEDACMD="$STEAMCOMPATOOLS/luxtorpeda/luxtorpeda.sh"; fi
 		if [ -z "$LUXTORPEDAARGS" ]						; then	LUXTORPEDAARGS="wait-before-run"; fi
 		if [ -z "$RSVERS" ]								; then	RSVERS="5.9.1"; fi
 		if [ -z "$USERSSPEKVERS" ]						; then  USERSSPEKVERS="1"; fi


### PR DESCRIPTION
Came up in #1177.
Related: #1178.

Luxtorpeda now uses a different launch command; `luxtorpeda.sh` instead of `luxtorpeda`. This PR updates the default path so that it uses this newer one.

This won't retroactively affect global configs, it will only affect newly-created global configs. Not all users may be using a newer Luxtorpeda version that uses this newer entry point, but I think it makes sense for our default value to be what upstream uses as the default. If the path doesn't exist, then it won't show up in the Global Menu Yad box for it, and the user can surmise that the executable was not found and set the path themselves from here or in `global.conf` manually (similar to what I described for the invalid path in #1178).

TODO:
- [x] Check if the same applies for Roberta.
- [ ] Update [Luxtorpeda wiki](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Luxtorpeda) to note the new default path.
- [x] Version bump