### PR TITLE
HMM: *VERY* rudimentary support file for Shadow Generations

### DIFF
--- a/misc/hmmgames.txt
+++ b/misc/hmmgames.txt
@@ -6,3 +6,4 @@
 "Sonic Generations";"71340";"32";"hedgemmgens"
 "Sonic Lost World";"329440";"32";"hedgemmlw"
 "Sonic Origins";"1794960";"64";"hedgemmhite"
+"Shadow Generations";"2513280";"64";"hedgemmmillershadow"

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20241003-2"
+PROGVERS="v14.0.20241023-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"


### PR DESCRIPTION
Updated misc/hmmgames.txt to add rudimentary support _for Shadow Generations only_. Sonic Generations from Sonic X Shadow Generations (SonicGenerations2024/hedgemmmillersonic) is not yet implemented in HMM.