### PR TITLE
Avoid bash error when CUPROTOCOMPAT is unset

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20241025-1"
+PROGVERS="v14.0.20241228-1"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -4403,7 +4403,7 @@ function needNewProton {
 }
 
 function dlCustomProton {
-	if [ "$CUPROTOCOMPAT" -eq 1 ]; then
+	if [[ -n "$CUPROTOCOMPAT" && "$CUPROTOCOMPAT" -eq 1 ]]; then
 		CUPROEXTDIR="$STEAMCOMPATOOLS"
 	else
 		CUPROEXTDIR="$CUSTPROTEXTDIR"


### PR DESCRIPTION
```
% steamtinkerlaunch vortex install
/bin/steamtinkerlaunch: line 4406: [: : integer expression expected
```

This error occurs when `$CUPROTOCOMPAT` is unset. The error does not seem to prevent the script from working.

This PR checks whether it's empty before checking its value.

I'm a bit fuzzy on how to update `PROGVERS` here and would appreciate some guidance if this is to be accepted.