### PR TITLE
Add pacman post-update hook - wipe protoncsv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+.idea

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ install:
 	install -Dm644 README.md -t "$(PREFIX)/share/doc/steamtinkerlaunch"
 	install -Dm644 "misc/steamtinkerlaunch.desktop" -t "$(PREFIX)/share/applications"
 	install -Dm644 "misc/steamtinkerlaunch.svg" -t "$(PREFIX)/share/icons/hicolor/scalable/apps"
+	ifeq (, $(shell which pacman))
+		install -Dm644 "misc/proton.hook" -t "/etc/pacman.d/hooks"
+	endif
 
 uninstall:
 	rm -f "${PREFIX}/share/icons/hicolor/scalable/apps/steamtinkerlaunch.svg"

--- a/misc/proton.hook
+++ b/misc/proton.hook
@@ -1,0 +1,17 @@
+[Trigger]
+Operation=Install
+Operation=Upgrade
+Type=Package
+Target=proton
+Target=proton-cachyos
+Target=proton-slr
+Target=proton-cachyos-slr
+Target=proton-ge
+Target=proton-ge-custom-bin
+
+[Action]
+Description=Remove launch-time fetched steamtinkerlaunch Proton versions to force list recompilation.
+Depends=coreutils
+When=PostTransaction
+NeedsTargets
+Exec=/usr/bin/rm -f /dev/shm/steamtinkerlaunch/ProtonCSV.txt


### PR DESCRIPTION
Wipes protoncsv.txt every time it's updated by pacman, to force recaching of proton versions.

Also, ignore .idea (jetbrains IDE project folder.)