### PR TITLE
Update proton list search to follow symlinks

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -2956,7 +2956,7 @@ function getAvailableProtonVersions {
 			# find new proton versions in CUSTPROTEXTDIR
 			if [ ! -f "$CUSTOMPROTONLIST" ] || [ "$(find "$CUSTPROTEXTDIR" -mindepth 1 -maxdepth 1 -type d | wc -l)" -gt "$(wc -l < "$CUSTOMPROTONLIST")" ]; then
 				writelog "INFO" "${FUNCNAME[0]} - Updating protonlist '$CUSTOMPROTONLIST' with possible new proton versions from '$CUSTPROTEXTDIR'"
-				find "$CUSTPROTEXTDIR" -type f -name "proton" >> "$CUSTOMPROTONLIST"
+				find -L "$CUSTPROTEXTDIR" -type f -name "proton" >> "$CUSTOMPROTONLIST"
 			fi
 
 			if [ ! -f "$PROTONCSV" ] || { [ -n "$1" ] && [ "$1" = "up" ]; } || [ "$1" == "F" ]; then

--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -2954,7 +2954,7 @@ function getAvailableProtonVersions {
 			delEmptyFile "$PROTONCSV"
 
 			# find new proton versions in CUSTPROTEXTDIR
-			if [ ! -f "$CUSTOMPROTONLIST" ] || [ "$(find "$CUSTPROTEXTDIR" -mindepth 1 -maxdepth 1 -type d | wc -l)" -gt "$(wc -l < "$CUSTOMPROTONLIST")" ]; then
+			if [ ! -f "$CUSTOMPROTONLIST" ] || [ "$(find -L "$CUSTPROTEXTDIR" -mindepth 1 -maxdepth 1 -type d | wc -l)" -gt "$(wc -l < "$CUSTOMPROTONLIST")" ]; then
 				writelog "INFO" "${FUNCNAME[0]} - Updating protonlist '$CUSTOMPROTONLIST' with possible new proton versions from '$CUSTPROTEXTDIR'"
 				find -L "$CUSTPROTEXTDIR" -type f -name "proton" >> "$CUSTOMPROTONLIST"
 			fi


### PR DESCRIPTION
Currently if you have Symlinked your Proton Versions into the $CUSTPROTEXTDIR Folder it wont get Auto-Detected
By Adjusting the find command to follow Symlinks it should be able to do so