### PR TITLE
overlay: Empty LD_PRELOAD early to avoid Steam overlay launch deadlock

### DIFF
--- a/steamtinkerlaunch
+++ b/steamtinkerlaunch
@@ -7,7 +7,7 @@
 PREFIX="/usr"
 PROGNAME="SteamTinkerLaunch"
 NICEPROGNAME="Steam Tinker Launch"
-PROGVERS="v14.0.20250602"
+PROGVERS="v14.0.20260707"
 PROGCMD="${0##*/}"
 PROGINTERNALPROTNAME="Proton-stl"
 SHOSTL="stl"
@@ -25350,7 +25350,10 @@ function saveOrgVars {
 	env | grep "=" | sort -o "$VARSIN"
 
 	# shellcheck disable=2034
-	ORG_LD_PRELOAD="$LD_PRELOAD"
+	# Keep the value main saved before it emptied LD_PRELOAD (see the overlay-deadlock
+	# note after setAIDCfgs). Unset-only default so an intentionally-empty saved value
+	# is preserved rather than overwritten with the current (already empty) LD_PRELOAD.
+	ORG_LD_PRELOAD="${ORG_LD_PRELOAD-${LD_PRELOAD-}}"
 	# shellcheck disable=2034
 	ORG_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
 	# shellcheck disable=2034
@@ -27085,6 +27088,17 @@ function main {
 
 	initAID "$@"
 	setAIDCfgs
+
+	# Empty LD_PRELOAD before the fork-heavy logging below (loadLanguage and the rest
+	# of main). When STL runs as a compatibility tool with the Steam overlay enabled,
+	# Steam preloads gameoverlayrenderer.so into this shell via LD_PRELOAD. Its atfork
+	# handler deadlocks the short-lived subprocesses writelog spawns, so STL hangs here
+	# and never launches the game (Steam sits at "running"). saveOrgVars/emptyVars
+	# already clear LD_PRELOAD, but not until after getCurrentCommandline further down,
+	# which is too late. Save the original now so restoreOrgVars still gives the overlay
+	# back to the game at launch.
+	ORG_LD_PRELOAD="${ORG_LD_PRELOAD-${LD_PRELOAD-}}"
+	LD_PRELOAD=""
 
 	writelog "INFO" "${FUNCNAME[0]} - Current SteamTinkerLaunch working directory is '$( pwd )'"
 


### PR DESCRIPTION
# overlay: Empty LD_PRELOAD early to avoid Steam overlay launch deadlock

## Problem

With SteamTinkerLaunch set as the compatibility tool and the Steam in-game overlay enabled, launching a game hangs before the game starts. Steam sits at "running" (green) until the process is killed. The `waitforexitandrun` STL process stays alive but never spawns Proton or the game, and the per-game log stops partway through `loadLanguage`, right after `Loading found system wide .../english.txt`.

I hit this on God of War (appid 1593500) with proton-cachyos. The trigger is the overlay, not the game or the Proton build.

## Cause

When the overlay is enabled, Steam sets `LD_PRELOAD` to the 32-bit and 64-bit `gameoverlayrenderer.so` and STL inherits it. `main()` then runs many forked subprocesses (every `writelog` call spawns `echo`/`tee`/`date`), starting with `loadLanguage`, before `saveOrgVars`/`emptyVars` clear `LD_PRELOAD` further down (after `getCurrentCommandline`). The overlay library's atfork handler deadlocks one of those short-lived subprocesses, so `writelog` never returns and STL hangs during early init.

Under `bash -x`, the last statement that runs is `echo ... | tee -a "$PRELOG"` inside `writelog`, and the child never exits. From that point stderr fills with:

```
ERROR: ld.so: object '.../ubuntu12_32/gameoverlayrenderer.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS32): ignored.
pid <N> != <M>, skipping destruction (fork without exec?)
```

which is the overlay being preloaded into STL's own subprocesses and interfering with them.

## Fix

Clear `LD_PRELOAD` right after `setAIDCfgs`, before the fork-heavy logging, and stash the original in `ORG_LD_PRELOAD` first. `saveOrgVars` now keeps that stashed value instead of overwriting it, so `restoreOrgVars` still hands the overlay back to the game at launch. The overlay keeps working in-game; only STL's own shell runs without it.

This reuses the existing `saveOrgVars` / `emptyVars` / `restoreOrgVars` path, so it is the same mechanism STL already relies on, applied before the first heavy logging instead of after `getCurrentCommandline`.

## Testing

Reproduced by capturing the environment Steam passes to STL and running `waitforexitandrun` by hand:

- Overlay `LD_PRELOAD` present, unpatched: hangs in `writelog` during `loadLanguage`; no game process is ever created.
- Same environment, patched: reaches `## GAMESTART HERE ###`, launches the Proton command and the forked custom command, and both processes stay up.

`bash -n` passes on the patched script. `PROGVERS` bumped to `v14.0.20260707` per CONTRIBUTING.
